### PR TITLE
fix issue : can't irerate on a dict in python3

### DIFF
--- a/casbin/rbac/default_role_manager/role_manager.py
+++ b/casbin/rbac/default_role_manager/role_manager.py
@@ -16,7 +16,7 @@ class RoleManager(RoleManager):
         return name in list(self.all_roles.keys())
 
     def create_role(self, name):
-        if name not in self.all_roles.keys():
+        if name not in list(self.all_roles.keys()):
             self.all_roles[name] = Role(name)
 
         return self.all_roles[name]

--- a/casbin/rbac/default_role_manager/role_manager.py
+++ b/casbin/rbac/default_role_manager/role_manager.py
@@ -13,7 +13,7 @@ class RoleManager(RoleManager):
         self.max_hierarchy_level = max_hierarchy_level
 
     def has_role(self, name):
-        return name in self.all_roles.keys()
+        return name in list(self.all_roles.keys())
 
     def create_role(self, name):
         if name not in self.all_roles.keys():


### PR DESCRIPTION
File : rbac/default_role_manager/role_manager.py
Line : 15~16
```
 def has_role(self, name):
        return name in self.all_roles.keys()
```

Error : In python3 you can't iterate on a dict

Fix : 
```
-        return name in self.all_roles.keys()
+        return name in list(self.all_roles.keys())
```

see : https://github.com/casbin/pycasbin/issues/1