### PR TITLE
Fix logging problem when passing objects as parameters into enforce()

### DIFF
--- a/casbin/enforcer.py
+++ b/casbin/enforcer.py
@@ -286,7 +286,7 @@ class Enforcer:
         # Log request.
         if log.get_logger().is_enabled():
             req_str = "Request: "
-            req_str = req_str + ", ".join(rvals)
+            req_str = req_str + ", ".join([str(v) for v in rvals])
 
             req_str = req_str + " ---> %s" % result
             log.log_print(req_str)

--- a/tests/test_enforcer.py
+++ b/tests/test_enforcer.py
@@ -121,3 +121,11 @@ class TestConfig(TestCase):
         self.assertFalse(e.enforce('bob', 'data1', 'write'))
         self.assertFalse(e.enforce('bob', 'data2', 'read'))
         self.assertTrue(e.enforce('bob', 'data2', 'write'))
+
+    def test_enforce_abac_log_enabled(self):
+        e = get_enforcer(get_examples("abac_model.conf"), enable_log=True)
+        e.enable_log(True)
+
+        sub = 'alice'
+        obj = {'Owner': 'alice', 'id': 'data1'}
+        self.assertTrue(e.enforce(sub, obj, 'write'))


### PR DESCRIPTION
Fixed bug when logging was enabled and passing in objects as parameters into enforce