### PR TITLE
fix for empty policy list

### DIFF
--- a/casbin/enforcer.py
+++ b/casbin/enforcer.py
@@ -271,7 +271,7 @@ class Enforcer:
             for j, token in enumerate(self.model.model["r"]["r"].tokens):
                 parameters[token] = rvals[j]
 
-            for token in enumerate(self.model.model["p"]["p"].tokens):
+            for token in self.model.model["p"]["p"].tokens:
                 parameters[token] = ""
 
             result = expression.evaluate(exp_string, parameters, functions)


### PR DESCRIPTION
Empty policy list causes error
NameNotDefined 'p_sub' is not defined for expression ...
because the token is represented by tuple in this string