### PR TITLE
Code optimisation.

### DIFF
--- a/casbin/util/builtin_operators.py
+++ b/casbin/util/builtin_operators.py
@@ -2,6 +2,10 @@ import re
 import ipaddress
 
 
+KEY_MATCH2_PATTERN = re.compile(r'(.*):[^\/]+(.*)')
+KEY_MATCH3_PATTERN = re.compile(r'(.*){[^\/]+}(.*)')
+
+
 def key_match(key1, key2):
     """determines whether key1 matches the pattern of key2 (similar to RESTful path), key2 can contain a *.
     For example, "/foo/bar" matches "/foo/*"
@@ -32,12 +36,11 @@ def key_match2(key1, key2):
 
     key2 = key2.replace("/*", "/.*")
 
-    pattern = re.compile(r'(.*):[^\/]+(.*)')
     while True:
         if "/:" not in key2:
             break
 
-        key2 = "^" + pattern.sub(r'\g<1>[^\/]+\g<2>', key2, 0) + "$"
+        key2 = "^" + KEY_MATCH2_PATTERN.sub(r'\g<1>[^\/]+\g<2>', key2, 0) + "$"
 
     return regex_match(key1, key2)
 
@@ -56,12 +59,11 @@ def key_match3(key1, key2):
 
     key2 = key2.replace("/*", "/.*")
 
-    pattern = re.compile(r'(.*){[^\/]+}(.*)')
     while True:
         if "{" not in key2:
             break
 
-        key2 = pattern.sub(r'\g<1>[^\/]+\g<2>', key2, 0)
+        key2 = KEY_MATCH3_PATTERN.sub(r'\g<1>[^\/]+\g<2>', key2, 0)
 
     return regex_match(key1, key2)
 

--- a/casbin/util/util.py
+++ b/casbin/util/util.py
@@ -1,3 +1,6 @@
+from collections import OrderedDict
+
+
 def escape_assertion(s):
     """escapes the dots in the assertion, because the expression evaluation doesn't support such variable names."""
 
@@ -19,15 +22,7 @@ def remove_comments(s):
 
 def array_remove_duplicates(s):
     """removes any duplicated elements in a string array."""
-    found = dict()
-    j = 0
-    for x in s:
-        if x not in found.keys():
-            found[x] = True
-            s[j] = x
-            j = j + 1
-
-    return s[:j]
+    return list(OrderedDict.fromkeys(s))
 
 
 def array_to_string(s):


### PR DESCRIPTION
Rewrote `casbin.util.util.array_remove_duplicates` function to be more faster and pythonic.

Benchmarks:

```
# Original version
python -m timeit -n 100000 -r 10 'from casbin.util.util import array_remove_duplicates; array_remove_duplicates(["one", "one", "two", "two", "three"])'
100000 loops, best of 10: 2.49 usec per loop


# New version
python -m timeit -n 100000 -r 10 'from casbin.util.util import array_remove_duplicates; array_remove_duplicates(["one", "one", "two", "two", "three"])'
100000 loops, best of 10: 2.19 usec per loop
```

There are even more efficient implementation possible if order may not be preserved. Current implementation follows original implementation and preserves order.

Also i moved regular expressions to module level because regexp compilation is an extensive operation and it is recommended to do such operations on module level.