### PR TITLE
Fix syntax errors on multiline config sentences

### DIFF
--- a/casbin/config/config.py
+++ b/casbin/config/config.py
@@ -75,6 +75,7 @@ class Config:
                 p = ''
                 if self.DEFAULT_MULTI_LINE_SEPARATOR == line[-1]:
                     p = line[0:-1].strip()
+                    p = p + ' ' 
                 else:
                     p = line
                     can_write = True

--- a/tests/config/test.ini
+++ b/tests/config/test.ini
@@ -31,15 +31,15 @@ key1 = test key
 # multi-line test
 [multi1]
 name = r.sub==p.sub \
-   &&r.obj==p.obj\
+   && r.obj==p.obj\
    \
 [multi2]
 name = r.sub==p.sub \
-   &&r.obj==p.obj
+   && r.obj==p.obj
 
 [multi3]
 name = r.sub==p.sub \
-   &&r.obj==p.obj
+   && r.obj==p.obj
 
 [multi4]
 name = \
@@ -48,5 +48,5 @@ name = \
 
 [multi5]
 name = r.sub==p.sub \
-   &&r.obj==p.obj\
+   && r.obj==p.obj\
    \

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -33,8 +33,8 @@ class TestConfig(TestCase):
 
         config.set("other::key1", "test key")
 
-        self.assertEqual(config.get("multi1::name"), "r.sub==p.sub&&r.obj==p.obj")
-        self.assertEqual(config.get("multi2::name"), "r.sub==p.sub&&r.obj==p.obj")
-        self.assertEqual(config.get("multi3::name"), "r.sub==p.sub&&r.obj==p.obj")
+        self.assertEqual(config.get("multi1::name"), "r.sub==p.sub && r.obj==p.obj")
+        self.assertEqual(config.get("multi2::name"), "r.sub==p.sub && r.obj==p.obj")
+        self.assertEqual(config.get("multi3::name"), "r.sub==p.sub && r.obj==p.obj")
         self.assertEqual(config.get("multi4::name"), "")
-        self.assertEqual(config.get("multi5::name"), "r.sub==p.sub&&r.obj==p.obj")
+        self.assertEqual(config.get("multi5::name"), "r.sub==p.sub && r.obj==p.obj")


### PR DESCRIPTION
- The actual code strips the multiline char but sometimes
it leads to syntax errors because not compatible chars may
result appended.