### PR TITLE
Implements ABAP eval function #57

### DIFF
--- a/casbin/model/function.py
+++ b/casbin/model/function.py
@@ -14,6 +14,7 @@ class FunctionMap:
         fm.add_function("keyMatch2", util.key_match2_func)
         fm.add_function("regexMatch", util.regex_match_func)
         fm.add_function("ipMatch", util.ip_match_func)
+        fm.add_function("eval", util.eval_func)
 
         return fm
 

--- a/casbin/util/builtin_operators.py
+++ b/casbin/util/builtin_operators.py
@@ -4,6 +4,7 @@ import ipaddress
 
 KEY_MATCH2_PATTERN = re.compile(r'(.*):[^\/]+(.*)')
 KEY_MATCH3_PATTERN = re.compile(r'(.*){[^\/]+}(.*)')
+PROPERTY_ACCESS_PATTERN = re.compile(r'(?P<prefix>.*)(\.(?P<content>.+?))(?P<suffix> .*)')
 
 
 def key_match(key1, key2):
@@ -131,3 +132,14 @@ def generate_g_function(rm):
             return rm.has_link(name1, name2, domain)
 
     return f
+
+def eval_func(*args):
+    expr = args[0].replace("&&", "and")
+    expr = expr.replace("||", "or")
+    old_expr = ""
+    while expr != old_expr:
+        old_expr = expr
+        expr = re.sub(PROPERTY_ACCESS_PATTERN, '\g<prefix>["\g<content>"]\g<suffix>', old_expr)
+    sub = args[1]
+
+    return eval(expr)

--- a/tests/util/test_builtin_operators.py
+++ b/tests/util/test_builtin_operators.py
@@ -42,3 +42,9 @@ class TestBuiltinOperators(TestCase):
         self.assertTrue(util.key_match2_func("/alice/all", "/:id/all"))
         self.assertFalse(util.key_match2_func("/alice", "/:id/all"))
         self.assertFalse(util.key_match2_func("/alice/all", "/:id"))
+    
+    def test_eval(self):
+        self.assertTrue(util.eval_func("sub.Age >= 18", { 'name' : 'Alice', 'Age': 32 }))
+        self.assertFalse(util.eval_func("sub.Age >= 18", { 'name' : 'Alice', 'Age': 13 }))
+        self.assertFalse(util.eval_func("sub.Age >= 18 && sub.name == 'Alice'", { 'name' : 'Thomas', 'Age': 22 }))
+        self.assertTrue(util.eval_func("sub.Age >= 18 && sub.name == 'Alice'", { 'name' : 'Alice', 'Age': 22 }))


### PR DESCRIPTION
Fix: https://github.com/casbin/pycasbin/issues/57

@hsluoyz 

Hi,

care to have a look at this implementation? I know it has at least one flaw: the arity of `eval` is not right (but I did not manage to figure out how to bind context, so that we don't have to pass second param (with the request sub)). 