### PR TITLE
Add support for N role link values

### DIFF
--- a/casbin/model/assertion.py
+++ b/casbin/model/assertion.py
@@ -20,12 +20,7 @@ class Assertion:
             if len(rule) < count:
                 raise RuntimeError("grouping policy elements do not meet role definition")
 
-            if count == 2:
-                self.rm.add_link(rule[0], rule[1])
-            elif count == 3:
-                self.rm.add_link(rule[0], rule[1], rule[2])
-            elif count == 4:
-                self.rm.add_link(rule[0], rule[1], rule[2], rule[3])
+            self.rm.add_link(*rule[:count])
 
         log.log_print("Role links for: " + self.key)
         self.rm.print_roles()


### PR DESCRIPTION
We currently have a need for a `count == 5` but I see no reason where there can't be an arbitrary number of arguments here.