### PR TITLE
fix: improve KeyMatch and add tests

### DIFF
--- a/casbin/util/builtin_operators.py
+++ b/casbin/util/builtin_operators.py
@@ -1,9 +1,8 @@
 import re
 import ipaddress
 
-
-KEY_MATCH2_PATTERN = re.compile(r'(.*):[^\/]+(.*)')
-KEY_MATCH3_PATTERN = re.compile(r'(.*){[^\/]+}(.*)')
+KEY_MATCH2_PATTERN = re.compile(r'(.*?):[^\/]+(.*?)')
+KEY_MATCH3_PATTERN = re.compile(r'(.*?){[^\/]+}(.*?)')
 
 
 def key_match(key1, key2):
@@ -35,14 +34,9 @@ def key_match2(key1, key2):
     """
 
     key2 = key2.replace("/*", "/.*")
+    key2 = KEY_MATCH2_PATTERN.sub(r'\g<1>[^\/]+\g<2>', key2, 0)
 
-    while True:
-        if "/:" not in key2:
-            break
-
-        key2 = "^" + KEY_MATCH2_PATTERN.sub(r'\g<1>[^\/]+\g<2>', key2, 0) + "$"
-
-    return regex_match(key1, key2)
+    return regex_match(key1, "^" + key2 + "$")
 
 
 def key_match2_func(*args):
@@ -58,14 +52,9 @@ def key_match3(key1, key2):
     """
 
     key2 = key2.replace("/*", "/.*")
+    key2 = KEY_MATCH3_PATTERN.sub(r'\g<1>[^\/]+\g<2>', key2, 0)
 
-    while True:
-        if "{" not in key2:
-            break
-
-        key2 = KEY_MATCH3_PATTERN.sub(r'\g<1>[^\/]+\g<2>', key2, 0)
-
-    return regex_match(key1, key2)
+    return regex_match(key1, "^" + key2 + "$")
 
 
 def key_match3_func(*args):
@@ -100,7 +89,7 @@ def ip_match(ip1, ip2):
     """
     ip1 = ipaddress.ip_address(ip1)
     try:
-        network = ipaddress.ip_network(ip2, strict=True)
+        network = ipaddress.ip_network(ip2, strict=False)
         return ip1 in network
     except ValueError:
         return ip1 == ip2

--- a/tests/util/test_builtin_operators.py
+++ b/tests/util/test_builtin_operators.py
@@ -5,6 +5,7 @@ from casbin import util
 class TestBuiltinOperators(TestCase):
 
     def test_key_match(self):
+        self.assertFalse(util.key_match_func("/foo", "/"))
         self.assertTrue(util.key_match_func("/foo", "/foo"))
         self.assertTrue(util.key_match_func("/foo", "/foo*"))
         self.assertFalse(util.key_match_func("/foo", "/foo/*"))
@@ -15,15 +16,18 @@ class TestBuiltinOperators(TestCase):
         self.assertTrue(util.key_match_func("/foobar", "/foo*"))
         self.assertFalse(util.key_match_func("/foobar", "/foo/*"))
 
+        self.assertFalse(util.key_match2_func("/alice/all", "/:/all"))
+
     def test_key_match2(self):
+        self.assertFalse(util.key_match2_func("/foo", "/"))
         self.assertTrue(util.key_match2_func("/foo", "/foo"))
         self.assertTrue(util.key_match2_func("/foo", "/foo*"))
         self.assertFalse(util.key_match2_func("/foo", "/foo/*"))
-        self.assertTrue(util.key_match2_func("/foo/bar", "/foo"))  # different with KeyMatch.
-        self.assertTrue(util.key_match2_func("/foo/bar", "/foo*"))
+        self.assertFalse(util.key_match2_func("/foo/bar", "/foo"))  # different with KeyMatch.
+        self.assertFalse(util.key_match2_func("/foo/bar", "/foo*"))
         self.assertTrue(util.key_match2_func("/foo/bar", "/foo/*"))
-        self.assertTrue(util.key_match2_func("/foobar", "/foo"))  # different with KeyMatch.
-        self.assertTrue(util.key_match2_func("/foobar", "/foo*"))
+        self.assertFalse(util.key_match2_func("/foobar", "/foo"))  # different with KeyMatch.
+        self.assertFalse(util.key_match2_func("/foobar", "/foo*"))
         self.assertFalse(util.key_match2_func("/foobar", "/foo/*"))
 
         self.assertFalse(util.key_match2_func("/", "/:resource"))
@@ -42,3 +46,50 @@ class TestBuiltinOperators(TestCase):
         self.assertTrue(util.key_match2_func("/alice/all", "/:id/all"))
         self.assertFalse(util.key_match2_func("/alice", "/:id/all"))
         self.assertFalse(util.key_match2_func("/alice/all", "/:id"))
+
+        self.assertFalse(util.key_match2_func("/alice/all", "/:/all"))
+
+    def test_key_match3(self):
+        self.assertTrue(util.key_match3_func("/foo", "/foo"))
+        self.assertTrue(util.key_match3_func("/foo", "/foo*"))
+        self.assertFalse(util.key_match3_func("/foo", "/foo/*"))
+        self.assertFalse(util.key_match3_func("/foo/bar", "/foo"))
+        self.assertFalse(util.key_match3_func("/foo/bar", "/foo*"))
+        self.assertTrue(util.key_match3_func("/foo/bar", "/foo/*"))
+        self.assertFalse(util.key_match3_func("/foobar", "/foo"))
+        self.assertFalse(util.key_match3_func("/foobar", "/foo*"))
+        self.assertFalse(util.key_match3_func("/foobar", "/foo/*"))
+
+        self.assertFalse(util.key_match3_func("/", "/{resource}"))
+        self.assertTrue(util.key_match3_func("/resource1", "/{resource}"))
+        self.assertFalse(util.key_match3_func("/myid", "/{id}/using/{resId}"))
+        self.assertTrue(util.key_match3_func("/myid/using/myresid", "/{id}/using/{resId}"))
+
+        self.assertFalse(util.key_match3_func("/proxy/myid", "/proxy/{id}/*"))
+        self.assertTrue(util.key_match3_func("/proxy/myid/", "/proxy/{id}/*"))
+        self.assertTrue(util.key_match3_func("/proxy/myid/res", "/proxy/{id}/*"))
+        self.assertTrue(util.key_match3_func("/proxy/myid/res/res2", "/proxy/{id}/*"))
+        self.assertTrue(util.key_match3_func("/proxy/myid/res/res2/res3", "/proxy/{id}/*"))
+        self.assertFalse(util.key_match3_func("/proxy/", "/proxy/{id}/*"))
+
+        self.assertFalse(util.key_match3_func("/myid/using/myresid", "/{id/using/{resId}"))
+
+    def test_regex_match(self):
+        self.assertTrue(util.regex_match_func("/topic/create", "/topic/create"))
+        self.assertTrue(util.regex_match_func("/topic/create/123", "/topic/create"))
+        self.assertFalse(util.regex_match_func("/topic/delete", "/topic/create"))
+        self.assertFalse(util.regex_match_func("/topic/edit", "/topic/edit/[0-9]+"))
+        self.assertTrue(util.regex_match_func("/topic/edit/123", "/topic/edit/[0-9]+"))
+        self.assertFalse(util.regex_match_func("/topic/edit/abc", "/topic/edit/[0-9]+"))
+        self.assertFalse(util.regex_match_func("/foo/delete/123", "/topic/delete/[0-9]+"))
+        self.assertTrue(util.regex_match_func("/topic/delete/0", "/topic/delete/[0-9]+"))
+        self.assertFalse(util.regex_match_func("/topic/edit/123s", "/topic/delete/[0-9]+"))
+
+    def test_ip_match(self):
+        self.assertTrue(util.ip_match_func("192.168.2.123", "192.168.2.0/24"))
+        self.assertFalse(util.ip_match_func("192.168.2.123", "192.168.3.0/24"))
+        self.assertTrue(util.ip_match_func("192.168.2.123", "192.168.2.0/16"))
+        self.assertTrue(util.ip_match_func("192.168.2.123", "192.168.2.123"))
+        self.assertTrue(util.ip_match_func("192.168.2.123", "192.168.2.123/32"))
+        self.assertTrue(util.ip_match_func("10.0.0.11", "10.0.0.0/8"))
+        self.assertFalse(util.ip_match_func("11.0.0.123", "10.0.0.0/8"))


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Fixes and Improves 

- fix `keyMatch2` doesn't work - `keyMatch2("/foo", "/")` returns `True`
- fix `ipMatch`, It doesn't support CIDR model - `ipMatch("192.168.2.123", "192.168.2.0/16")` 
- improve KeyMatch to avoid endless loop - `keyMatch2("/:/all", "/:/all")`, `keyMatch2("/{/all", "/{/all")`
- add more tests

fixes: #84, #87 
