### PR TITLE
fix eval function

### DIFF
--- a/casbin/core_enforcer.py
+++ b/casbin/core_enforcer.py
@@ -231,15 +231,16 @@ class CoreEnforcer:
                 if len(p_tokens) != len(pvals):
                     raise RuntimeError("invalid policy size")
 
-                parameters = dict(r_parameters, **dict(zip(p_tokens, pvals)))
-                result = expression.eval(parameters)
+                p_parameters = dict(zip(p_tokens, pvals))
+                parameters = dict(r_parameters, **p_parameters)
 
                 if has_eval(exp_string):
                     rule_names = get_eval_value(exp_string)
-                    for rule_name in rule_names:
-                        j = p_tokens[rule_name]
-                        rule = escape_assertion(pvals[j])
-                        exp_string = replace_eval(exp_string, self.enforce(rule))
+                    rules = [escape_assertion(p_parameters[rule_name]) for rule_name in rule_names]
+                    exp_with_rule = replace_eval(exp_string, rules)
+                    expression = self._get_expression(exp_with_rule, functions)
+
+                result = expression.eval(parameters)
 
                 if isinstance(result, bool):
                     if not result:

--- a/casbin/util/util.py
+++ b/casbin/util/util.py
@@ -63,16 +63,20 @@ def set_subtract(a, b):
 
 def has_eval(s):
     '''determine whether matcher contains function eval'''
-    return eval_reg.match(s)
+    return eval_reg.search(s)
 
 
-def replace_eval(s, rule):
-    '''replace function eval with the value of its parameters'''
-    if has_eval(s):
-        return eval_reg.sub("(" + rule + ")", s)
-    else:
-        return s
+def replace_eval(expr, rules):
+    ''' replace all occurences of function eval with rules '''
+    pos = 0
+    match = eval_reg.search(expr, pos)
+    while match:
+        rule = "({rule})".format(rule=rules.pop(0))
+        expr = expr[:match.start()] + rule + expr[match.end():]
+        pos = match.start() + len(rule)
+        match = eval_reg.search(expr, pos)
 
+    return expr
 
 def get_eval_value(s):
     '''returns the parameters of function eval'''

--- a/examples/abac_multiple_rules_model.conf
+++ b/examples/abac_multiple_rules_model.conf
@@ -1,0 +1,11 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub_rule, sub_rule2, obj, act
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = r.obj == p.obj && r.act == p.act && eval(p.sub_rule) && eval(p.sub_rule2)

--- a/examples/abac_multiple_rules_policy.csv
+++ b/examples/abac_multiple_rules_policy.csv
@@ -1,0 +1,2 @@
+p, r.sub.age > 18, r.sub.name == "alice", /data1, read
+p, r.sub.age < 60, r.sub.name == "bob", /data2, write

--- a/examples/abac_rule_model.conf
+++ b/examples/abac_rule_model.conf
@@ -1,0 +1,11 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub_rule, obj, act
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = eval(p.sub_rule) && r.obj == p.obj && r.act == p.act

--- a/examples/abac_rule_policy.csv
+++ b/examples/abac_rule_policy.csv
@@ -1,0 +1,2 @@
+p, r.sub.age > 18, /data1, read
+p, r.sub.age < 60, /data2, write

--- a/tests/test_enforcer.py
+++ b/tests/test_enforcer.py
@@ -15,6 +15,11 @@ def get_examples(path):
     examples_path = os.path.split(os.path.realpath(__file__))[0] + "/../examples/"
     return os.path.abspath(examples_path + path)
 
+class TestSub():
+
+    def __init__(self, name, age):
+        self.name = name
+        self.age = age
 
 class TestConfig(TestCase):
     def test_enforcer_basic(self):
@@ -162,3 +167,55 @@ class TestConfig(TestCase):
         sub = 'alice'
         obj = {'Owner': 'alice', 'id': 'data1'}
         self.assertTrue(e.enforce(sub, obj, 'write'))
+
+    def test_abac_with_sub_rule(self):
+        e = get_enforcer(get_examples("abac_rule_model.conf"),
+                         get_examples("abac_rule_policy.csv"))
+
+        sub1 = TestSub("alice", 16)
+        sub2 = TestSub("bob", 20)
+        sub3 = TestSub("alice", 65)
+        
+        self.assertFalse(e.enforce(sub1, "/data1", "read"))
+        self.assertFalse(e.enforce(sub1, "/data2", "read"))
+        self.assertFalse(e.enforce(sub1, "/data1", "write"))
+        self.assertTrue(e.enforce(sub1, "/data2", "write"))
+
+        self.assertTrue(e.enforce(sub2, "/data1", "read"))
+        self.assertFalse(e.enforce(sub2, "/data2", "read"))
+        self.assertFalse(e.enforce(sub2, "/data1", "write"))
+        self.assertTrue(e.enforce(sub2, "/data2", "write"))
+
+        self.assertTrue(e.enforce(sub3, "/data1", "read"))
+        self.assertFalse(e.enforce(sub3, "/data2", "read"))
+        self.assertFalse(e.enforce(sub3, "/data1", "write"))
+        self.assertFalse(e.enforce(sub3, "/data2", "write"))
+
+    def test_abac_with_multiple_sub_rules(self):
+        e = get_enforcer(get_examples("abac_multiple_rules_model.conf"),
+                         get_examples("abac_multiple_rules_policy.csv"))
+
+        sub1 = TestSub("alice", 16)
+        sub2 = TestSub("alice", 20)
+        sub3 = TestSub("bob", 65)
+        sub4 = TestSub("bob", 35)
+        
+        self.assertFalse(e.enforce(sub1, "/data1", "read"))
+        self.assertFalse(e.enforce(sub1, "/data2", "read"))
+        self.assertFalse(e.enforce(sub1, "/data1", "write"))
+        self.assertFalse(e.enforce(sub1, "/data2", "write"))
+
+        self.assertTrue(e.enforce(sub2, "/data1", "read"))
+        self.assertFalse(e.enforce(sub2, "/data2", "read"))
+        self.assertFalse(e.enforce(sub2, "/data1", "write"))
+        self.assertFalse(e.enforce(sub2, "/data2", "write"))
+
+        self.assertFalse(e.enforce(sub3, "/data1", "read"))
+        self.assertFalse(e.enforce(sub3, "/data2", "read"))
+        self.assertFalse(e.enforce(sub3, "/data1", "write"))
+        self.assertFalse(e.enforce(sub3, "/data2", "write"))
+
+        self.assertFalse(e.enforce(sub4, "/data1", "read"))
+        self.assertFalse(e.enforce(sub4, "/data2", "read"))
+        self.assertFalse(e.enforce(sub4, "/data1", "write"))
+        self.assertTrue(e.enforce(sub4, "/data2", "write"))

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -27,6 +27,7 @@ class TestUtil(TestCase):
 
     def test_has_eval(self):
         self.assertTrue(util.has_eval("eval() && a && b && c"))
+        self.assertTrue(util.has_eval("a && b && eval(c)"))
         self.assertFalse(util.has_eval("eval) && a && b && c"))
         self.assertFalse(util.has_eval("eval)( && a && b && c"))
         self.assertTrue(util.has_eval("eval(c * (a + b)) && a && b && c"))
@@ -34,8 +35,8 @@ class TestUtil(TestCase):
         self.assertTrue(util.has_eval("eval(a) && eval(b) && a && b && c"))
 
     def test_replace_eval(self):
-        self.assertEqual(util.replace_eval("eval() && a && b && c", "a"), "(a) && a && b && c")
-        self.assertEqual(util.replace_eval("eval() && a && b && c", "(a)"), "((a)) && a && b && c")
+        self.assertEqual(util.replace_eval("eval(a) && eval(b) && c", ["a", "b"]), "(a) && (b) && c")
+        self.assertEqual(util.replace_eval("a && eval(b) && eval(c)", ["b", "c"]), "a && (b) && (c)")
 
     def test_get_eval_value(self):
         self.assertEqual(util.get_eval_value("eval(a) && a && b && c"), ["a"])


### PR DESCRIPTION
Fix: #57, #68

Changelog:

- replace eval functions before expression gets executed
- fix `calbin.util.util.has_eval`
- fix `calbin.util.util.replace_eval`
- add examples

Signed-off-by: Andreas Bichinger <andreas.bichinger@gmail.com>