### PR TITLE
feat: add glob pattern matching using fnmatch module

### DIFF
--- a/casbin/model/function.py
+++ b/casbin/model/function.py
@@ -14,6 +14,7 @@ class FunctionMap:
         fm.add_function("keyMatch2", util.key_match2_func)
         fm.add_function("regexMatch", util.regex_match_func)
         fm.add_function("ipMatch", util.ip_match_func)
+        fm.add_function("globMatch", util.glob_match_func)
 
         return fm
 

--- a/casbin/util/builtin_operators.py
+++ b/casbin/util/builtin_operators.py
@@ -1,3 +1,4 @@
+import fnmatch
 import re
 import ipaddress
 
@@ -81,6 +82,20 @@ def regex_match_func(*args):
     name2 = args[1]
 
     return regex_match(name1, name2)
+
+
+def glob_match(string, pattern):
+    """determines whether string matches the pattern in glob expression."""
+    return fnmatch.fnmatch(string, pattern)
+
+
+def glob_match_func(*args):
+    """the wrapper for globMatch."""
+
+    string = args[0]
+    pattern = args[1]
+
+    return glob_match(string, pattern)
 
 
 def ip_match(ip1, ip2):

--- a/tests/util/test_builtin_operators.py
+++ b/tests/util/test_builtin_operators.py
@@ -85,6 +85,37 @@ class TestBuiltinOperators(TestCase):
         self.assertTrue(util.regex_match_func("/topic/delete/0", "/topic/delete/[0-9]+"))
         self.assertFalse(util.regex_match_func("/topic/edit/123s", "/topic/delete/[0-9]+"))
 
+    def test_glob_match(self):
+        self.assertTrue(util.glob_match_func("/foo", "/foo"))
+        self.assertTrue(util.glob_match_func("/foo", "/foo*"))
+        self.assertFalse(util.glob_match_func("/foo", "/foo/*"))
+        self.assertFalse(util.glob_match_func("/foo/bar", "/foo"))
+        self.assertTrue(util.glob_match_func("/foo/bar", "/foo*"))  # differ from Casbin Go
+        self.assertTrue(util.glob_match_func("/foo/bar", "/foo/*"))
+        self.assertFalse(util.glob_match_func("/foobar", "/foo"))
+        self.assertTrue(util.glob_match_func("/foobar", "/foo*"))
+        self.assertFalse(util.glob_match_func("/foobar", "/foo/*"))
+
+        self.assertTrue(util.glob_match_func("/prefix/foo", "*/foo")) # differ from Casbin Go
+        self.assertTrue(util.glob_match_func("/prefix/foo", "*/foo*")) # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/prefix/foo", "*/foo/*"))
+        self.assertFalse(util.glob_match_func("/prefix/foo/bar", "*/foo"))
+        self.assertTrue(util.glob_match_func("/prefix/foo/bar", "*/foo*")) # differ from Casbin Go
+        self.assertTrue(util.glob_match_func("/prefix/foo/bar", "*/foo/*")) # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/prefix/foobar", "*/foo"))
+        self.assertTrue(util.glob_match_func("/prefix/foobar", "*/foo*")) # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/prefix/foobar", "*/foo/*"))
+
+        self.assertTrue(util.glob_match_func("/prefix/subprefix/foo", "*/foo")) # differ from Casbin Go
+        self.assertTrue(util.glob_match_func("/prefix/subprefix/foo", "*/foo*")) # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/prefix/subprefix/foo", "*/foo/*"))
+        self.assertFalse(util.glob_match_func("/prefix/subprefix/foo/bar", "*/foo"))
+        self.assertTrue(util.glob_match_func("/prefix/subprefix/foo/bar", "*/foo*")) # differ from Casbin Go
+        self.assertTrue(util.glob_match_func("/prefix/subprefix/foo/bar", "*/foo/*")) # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/prefix/subprefix/foobar", "*/foo"))
+        self.assertTrue(util.glob_match_func("/prefix/subprefix/foobar", "*/foo*")) # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/prefix/subprefix/foobar", "*/foo/*"))
+
     def test_ip_match(self):
         self.assertTrue(util.ip_match_func("192.168.2.123", "192.168.2.0/24"))
         self.assertFalse(util.ip_match_func("192.168.2.123", "192.168.3.0/24"))


### PR DESCRIPTION
Hi !

This PR will add the function globMatch in the models.

It's based on the fnmatch module and the behavior will differ a bit from the globMatch function available in https://github.com/casbin/casbin. For example `globMatch("/foo/bar/123", "/foo*")` returns True in pycasbin but False in casbin

Don't hesitate to let me know if you have any question.

Thanks !

