### PR TITLE
fix: wrong domain length judge

### DIFF
--- a/casbin/rbac/default_role_manager/role_manager.py
+++ b/casbin/rbac/default_role_manager/role_manager.py
@@ -47,9 +47,11 @@ class RoleManager(RoleManager):
 
     def add_link(self, name1, name2, *domain):
         if len(domain) == 1:
-            if len(domain[0]) > 1:
+            if isinstance(domain[0],str):
                 name1 = domain[0] + "::" + name1
                 name2 = domain[0] + "::" + name2
+            else:
+                raise RuntimeError("error: domain should not be empty")
         elif len(domain) > 1:
             raise RuntimeError("error: domain should be 1 parameter")
 
@@ -70,9 +72,11 @@ class RoleManager(RoleManager):
 
     def delete_link(self, name1, name2, *domain):
         if len(domain) == 1:
-            if len(domain[0]) > 1:
+            if isinstance(domain[0],str):
                 name1 = domain[0] + "::" + name1
                 name2 = domain[0] + "::" + name2
+            else:
+                raise RuntimeError("error: domain should not be empty")
         elif len(domain) > 1:
             raise RuntimeError("error: domain should be 1 parameter")
 

--- a/tests/rbac/test_role_manager.py
+++ b/tests/rbac/test_role_manager.py
@@ -113,6 +113,12 @@ class TestDefaultRoleManager(TestCase):
         self.assertTrue(rm.has_link("u4", "admin", "domain1"))
         self.assertTrue(rm.has_link("u4", "admin", "domain2"))
 
+    # In 0.20.0 and 1.0.0, when length of the domain name is 1, role manager won't work as expected.
+    def test_domain_role_edge_condition(self):
+        rm = get_role_manager()
+        rm.add_link("u1", "g1", "d")
+        self.assertTrue(rm.has_link("u1", "g1", "d"))
+
     def test_clear(self):
         rm = get_role_manager()
         rm.add_link("u1", "g1")


### PR DESCRIPTION
Signed-off-by: Zxilly <zhouxinyu1001@gmail.com>

fix: #135 

This bug exists in 1.0.0 and 0.20.0, and will happen if the length of the RBAC domain name is 1.