### PR TITLE
fix: r.user.name -> r_user_name instead of r_user.name in ABAC model

### DIFF
--- a/casbin/util/util.py
+++ b/casbin/util/util.py
@@ -6,8 +6,8 @@ eval_reg = re.compile(r'\beval\((?P<rule>[^)]*)\)')
 def escape_assertion(s):
     """escapes the dots in the assertion, because the expression evaluation doesn't support such variable names."""
 
-    s = s.replace("r.", "r_")
-    s = s.replace("p.", "p_")
+    s = re.sub(r'\br\.', 'r_', s)
+    s = re.sub(r'\bp\.', 'p_', s)
 
     return s
 


### PR DESCRIPTION
The use of `\.` is to prevent `p.rule` from being converted to `p_r_le`

Signed-off-by: lzxin <cnlzxin@gmail.com>