### PR TITLE
fix: replace fnmatch with wcmatch for glob match, keep same behavior with Go Casbin

### DIFF
--- a/casbin/util/builtin_operators.py
+++ b/casbin/util/builtin_operators.py
@@ -1,6 +1,7 @@
-import fnmatch
-import re
 import ipaddress
+import re
+
+from wcmatch import pathlib
 
 KEY_MATCH2_PATTERN = re.compile(r'(.*?):[^\/]+(.*?)')
 KEY_MATCH3_PATTERN = re.compile(r'(.*?){[^\/]+}(.*?)')
@@ -86,7 +87,7 @@ def regex_match_func(*args):
 
 def glob_match(string, pattern):
     """determines whether string matches the pattern in glob expression."""
-    return fnmatch.fnmatch(string, pattern)
+    return pathlib.Path(string).globmatch(pattern)
 
 
 def glob_match_func(*args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 simpleeval>=0.9.10
+wcmatch >= 8.1.2

--- a/tests/util/test_builtin_operators.py
+++ b/tests/util/test_builtin_operators.py
@@ -90,30 +90,30 @@ class TestBuiltinOperators(TestCase):
         self.assertTrue(util.glob_match_func("/foo", "/foo*"))
         self.assertFalse(util.glob_match_func("/foo", "/foo/*"))
         self.assertFalse(util.glob_match_func("/foo/bar", "/foo"))
-        self.assertTrue(util.glob_match_func("/foo/bar", "/foo*"))  # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/foo/bar", "/foo*"))
         self.assertTrue(util.glob_match_func("/foo/bar", "/foo/*"))
         self.assertFalse(util.glob_match_func("/foobar", "/foo"))
         self.assertTrue(util.glob_match_func("/foobar", "/foo*"))
         self.assertFalse(util.glob_match_func("/foobar", "/foo/*"))
 
-        self.assertTrue(util.glob_match_func("/prefix/foo", "*/foo")) # differ from Casbin Go
-        self.assertTrue(util.glob_match_func("/prefix/foo", "*/foo*")) # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/prefix/foo", "*/foo"))
+        self.assertFalse(util.glob_match_func("/prefix/foo", "*/foo*"))
         self.assertFalse(util.glob_match_func("/prefix/foo", "*/foo/*"))
         self.assertFalse(util.glob_match_func("/prefix/foo/bar", "*/foo"))
-        self.assertTrue(util.glob_match_func("/prefix/foo/bar", "*/foo*")) # differ from Casbin Go
-        self.assertTrue(util.glob_match_func("/prefix/foo/bar", "*/foo/*")) # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/prefix/foo/bar", "*/foo*"))
+        self.assertFalse(util.glob_match_func("/prefix/foo/bar", "*/foo/*"))
         self.assertFalse(util.glob_match_func("/prefix/foobar", "*/foo"))
-        self.assertTrue(util.glob_match_func("/prefix/foobar", "*/foo*")) # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/prefix/foobar", "*/foo*"))
         self.assertFalse(util.glob_match_func("/prefix/foobar", "*/foo/*"))
 
-        self.assertTrue(util.glob_match_func("/prefix/subprefix/foo", "*/foo")) # differ from Casbin Go
-        self.assertTrue(util.glob_match_func("/prefix/subprefix/foo", "*/foo*")) # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/prefix/subprefix/foo", "*/foo"))
+        self.assertFalse(util.glob_match_func("/prefix/subprefix/foo", "*/foo*"))
         self.assertFalse(util.glob_match_func("/prefix/subprefix/foo", "*/foo/*"))
         self.assertFalse(util.glob_match_func("/prefix/subprefix/foo/bar", "*/foo"))
-        self.assertTrue(util.glob_match_func("/prefix/subprefix/foo/bar", "*/foo*")) # differ from Casbin Go
-        self.assertTrue(util.glob_match_func("/prefix/subprefix/foo/bar", "*/foo/*")) # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/prefix/subprefix/foo/bar", "*/foo*"))
+        self.assertFalse(util.glob_match_func("/prefix/subprefix/foo/bar", "*/foo/*"))
         self.assertFalse(util.glob_match_func("/prefix/subprefix/foobar", "*/foo"))
-        self.assertTrue(util.glob_match_func("/prefix/subprefix/foobar", "*/foo*")) # differ from Casbin Go
+        self.assertFalse(util.glob_match_func("/prefix/subprefix/foobar", "*/foo*"))
         self.assertFalse(util.glob_match_func("/prefix/subprefix/foobar", "*/foo/*"))
 
     def test_ip_match(self):


### PR DESCRIPTION
fix: #148 

Signed-off-by: Zxilly <zhouxinyu1001@gmail.com>

ref to discussion at https://bugs.python.org/issue28718, it'll be complicated to implement it. 

So I have to introduce a new dependency `wcmatch`.