### PR TITLE
ci: remove python 3.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-18.04, macOS-latest, windows-latest]
         include:
           # pypy3 on Mac OS currently fails trying to compile


### PR DESCRIPTION
Signed-off-by: Zxilly <zhouxinyu1001@gmail.com>

Python 3.5 reached the end of its life on September 13th, 2020

@hsluoyz @techoner plz review