### PR TITLE
fix: added utf-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ desc_file = "README.md"
 
 here = path.abspath(path.dirname(__file__))
 
-with open(desc_file, "r") as fh:
+with open(desc_file, "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 # get the dependencies and installs


### PR DESCRIPTION
An encoding for "utf-8" has been added to the setup py script for facilitating setup in a windows environment.

ERROR MESSAGE BEFORE CHANGES (my local system):
Traceback (most recent call last):
File "setup.py", line 9, in
long_description = fh.read()
File "C:\Users\Swagat\anaconda3\lib\encodings\cp1252.py", line 23, in decode
return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 12735: character maps to

Fix: https://github.com/casbin/pycasbin/issues/192