### PR TITLE
fix: remove_filtered_policy_returns_effects inconsistent input

### DIFF
--- a/casbin/distributed_enforcer.py
+++ b/casbin/distributed_enforcer.py
@@ -84,7 +84,7 @@ class DistributedEnforcer(SyncedEnforcer):
                 self.logger.log("An exception occurred: " + e)
 
         effects = self.get_model().remove_filtered_policy_returns_effects(
-            sec, ptype, field_index, field_values
+            sec, ptype, field_index, *field_values
         )
 
         if sec == "g":

--- a/casbin/model/policy.py
+++ b/casbin/model/policy.py
@@ -238,7 +238,7 @@ class Policy:
         for rule in self[sec][ptype].policy:
             if all(
                 value == "" or rule[field_index + i] == value
-                for i, value in enumerate(field_values[0])
+                for i, value in enumerate(field_values)
             ):
                 effects.append(rule)
             else:


### PR DESCRIPTION
Signed-off-by: abingcbc <abingcbc626@gmail.com>

## What problem does this PR solve?

The input `field_values` of `remove_filtered_policy_returns` is like `("alice", "tom")`, but the one of `remove_filtered_policy_returns_effects` is like `(("alice", "tom"),)`.

## What is changed and how it works?
### remove_filtered_policy_returns_effects

Just use `field_values` but not `field_values[0]`. But it cannot pass the unit test, so we have to modify where it is used.

### remove_filtered_policy_self

The only usage of `remove_filtered_policy_returns_effects` is `remove_filtered_policy_self`. In this function, the original codes didn't unwrap the `field_values` and directly pass it to `remove_filtered_policy_returns_effects`. So we can unwrap `field_values` here and keep the input consistent with `remove_filtered_policy`.