### PR TITLE
feat: ignore policies with domain when get_implicit_permissions_for_user

### DIFF
--- a/casbin/enforcer.py
+++ b/casbin/enforcer.py
@@ -136,7 +136,9 @@ class Enforcer(ManagementEnforcer):
 
         return res
 
-    def get_implicit_permissions_for_user(self, user, domain=""):
+    def get_implicit_permissions_for_user(
+        self, user, domain="", filter_policy_dom=True
+    ):
         """
         gets implicit permissions for a user or role.
         Compared to get_permissions_for_user(), this function retrieves permissions for inherited roles.
@@ -147,6 +149,9 @@ class Enforcer(ManagementEnforcer):
 
         get_permissions_for_user("alice") can only get: [["alice", "data2", "read"]].
         But get_implicit_permissions_for_user("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
+
+        Inherited roles can be matched by domain.
+        filter_policy_dom: bool - For given *domain*, policies will be filtered by domain as well. Default = True
         """
         roles = self.get_implicit_roles_for_user(user, domain)
 
@@ -154,7 +159,7 @@ class Enforcer(ManagementEnforcer):
 
         res = []
         for role in roles:
-            if domain:
+            if domain and filter_policy_dom:
                 permissions = self.get_permissions_for_user_in_domain(role, domain)
             else:
                 permissions = self.get_permissions_for_user(role)

--- a/casbin/synced_enforcer.py
+++ b/casbin/synced_enforcer.py
@@ -443,7 +443,7 @@ class SyncedEnforcer:
         with self._rl:
             return self._e.get_implicit_roles_for_user(name, *domain)
 
-    def get_implicit_permissions_for_user(self, user, *domain):
+    def get_implicit_permissions_for_user(self, user, *domain, filter_policy_dom=True):
         """
         gets implicit permissions for a user or role.
         Compared to get_permissions_for_user(), this function retrieves permissions for inherited roles.
@@ -456,7 +456,9 @@ class SyncedEnforcer:
         But get_implicit_permissions_for_user("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
         """
         with self._rl:
-            return self._e.get_implicit_permissions_for_user(user, *domain)
+            return self._e.get_implicit_permissions_for_user(
+                user, *domain, filter_policy_dom=filter_policy_dom
+            )
 
     def get_implicit_users_for_permission(self, *permission):
         """

--- a/examples/rbac_with_domains_without_policy_matcher.conf
+++ b/examples/rbac_with_domains_without_policy_matcher.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, dom, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub, r.dom) && r.obj == p.obj && r.act == p.act

--- a/examples/rbac_with_hierarchy_without_policy_domains.csv
+++ b/examples/rbac_with_hierarchy_without_policy_domains.csv
@@ -1,0 +1,12 @@
+# All policies domain *neutral*. Only roles are domain dependent
+
+p, role:reader, data1, read
+p, role:writer, data1, write
+p, alice, data2, read
+
+g, role:global_admin, role:reader, domain1
+g, role:global_admin, role:writer, domain1
+
+g, alice, role:global_admin, domain1
+
+

--- a/tests/test_rbac_api.py
+++ b/tests/test_rbac_api.py
@@ -233,6 +233,37 @@ class TestRbacApi(TestCaseBase):
         )
         self.assertEqual(e.get_implicit_permissions_for_user("bob", "domain1"), [])
 
+    def test_enforce_implicit_permissions_api_with_domain_ignore_domain_policies_filter(
+        self,
+    ):
+        e = self.get_enforcer(
+            get_examples("rbac_with_domains_without_policy_matcher.conf"),
+            get_examples("rbac_with_hierarchy_without_policy_domains.csv"),
+        )
+
+        self.assertEqual(
+            e.get_roles_for_user_in_domain("alice", "domain1"), ["role:global_admin"]
+        )
+        self.assertEqual(
+            sorted(e.get_implicit_roles_for_user("alice", "domain1")),
+            sorted(["role:global_admin", "role:reader", "role:writer"]),
+        )
+        self.assertEqual(
+            sorted(
+                e.get_implicit_permissions_for_user(
+                    "alice", "domain1", filter_policy_dom=False
+                )
+            ),
+            sorted(
+                [
+                    ["alice", "data2", "read"],
+                    ["role:reader", "data1", "read"],
+                    ["role:writer", "data1", "write"],
+                ]
+            ),
+        )
+        self.assertEqual(e.get_implicit_permissions_for_user("bob", "domain1"), [])
+
     def test_enforce_get_users_in_domain(self):
         e = self.get_enforcer(
             get_examples("rbac_with_domains_model.conf"),


### PR DESCRIPTION
Fix: https://github.com/casbin/pycasbin/issues/214

Because of domain patterns in p records, we cannot filter policies by this kind of dynamic domains. 
`self.get_filtered_policy(0, user, domain)` .  
Thus we get empty permissions in this case.
Same goes policy records without domains