### PR TITLE
feat: get implicit permissions filter policies domain by matching function

### DIFF
--- a/examples/rbac_with_domain_and_policy_pattern_policy.csv
+++ b/examples/rbac_with_domain_and_policy_pattern_policy.csv
@@ -1,4 +1,5 @@
 p, admin, domain.*, data1, read
+p, user, domain.*, data3, read
 p, user, domain.1, data2, read
 p, user, domain.1, data2, write
 

--- a/tests/test_management_api.py
+++ b/tests/test_management_api.py
@@ -111,6 +111,7 @@ class TestManagementApi(TestCaseBase):
             e.get_policy(),
             [
                 ["admin", "domain.*", "data1", "read"],
+                ["user", "domain.*", "data3", "read"],
                 ["user", "domain.1", "data2", "read"],
                 ["user", "domain.1", "data2", "write"],
             ],
@@ -127,19 +128,24 @@ class TestManagementApi(TestCaseBase):
             [["alice", "user", "*"]],
         )
 
-        # first p record matches to domain.3
+        # first and second p record matches to domain.3
         self.assertEqual(
             e.get_filtered_policy(1, partial(km2_fn, "domain.3")),
-            [["admin", "domain.*", "data1", "read"]],
-        )
-
-        # first and second p record should be matched to (.., domain.1, read)
-        self.assertEqual(
-            e.get_filtered_policy(1, partial(km2_fn, "domain.1"), "", "read"),
             [
                 ["admin", "domain.*", "data1", "read"],
-                ["user", "domain.1", "data2", "read"],
+                ["user", "domain.*", "data3", "read"],
             ],
+        )
+
+        self.assertEqual(
+            sorted(e.get_filtered_policy(1, partial(km2_fn, "domain.1"), "", "read")),
+            sorted(
+                [
+                    ["admin", "domain.*", "data1", "read"],
+                    ["user", "domain.1", "data2", "read"],
+                    ["user", "domain.*", "data3", "read"],
+                ]
+            ),
         )
 
     def test_get_policy_multiple_matching_functions(self):
@@ -152,6 +158,7 @@ class TestManagementApi(TestCaseBase):
             e.get_policy(),
             [
                 ["admin", "domain.*", "data1", "read"],
+                ["user", "domain.*", "data3", "read"],
                 ["user", "domain.1", "data2", "read"],
                 ["user", "domain.1", "data2", "write"],
             ],
@@ -160,30 +167,47 @@ class TestManagementApi(TestCaseBase):
         km2_fn = casbin.util.key_match2_func
 
         self.assertEqual(
-            e.get_filtered_policy(
-                1, partial(km2_fn, "domain.2"), lambda a: "data" in a
+            sorted(
+                e.get_filtered_policy(
+                    1, partial(km2_fn, "domain.2"), lambda a: "data" in a
+                )
             ),
-            [["admin", "domain.*", "data1", "read"]],
+            sorted(
+                [
+                    ["admin", "domain.*", "data1", "read"],
+                    ["user", "domain.*", "data3", "read"],
+                ]
+            ),
         )
 
         self.assertEqual(
-            e.get_filtered_policy(
-                1, partial(km2_fn, "domain.1"), lambda a: "data" in a, "read"
+            sorted(
+                e.get_filtered_policy(
+                    1, partial(km2_fn, "domain.1"), lambda a: "data" in a, "read"
+                )
             ),
-            [
-                ["admin", "domain.*", "data1", "read"],
-                ["user", "domain.1", "data2", "read"],
-            ],
+            sorted(
+                [
+                    ["admin", "domain.*", "data1", "read"],
+                    ["user", "domain.1", "data2", "read"],
+                    ["user", "domain.*", "data3", "read"],
+                ]
+            ),
         )
 
         self.assertEqual(
-            e.get_filtered_policy(
-                1, partial(km2_fn, "domain.1"), "", "reading".startswith
+            sorted(
+                e.get_filtered_policy(
+                    1, partial(km2_fn, "domain.1"), "", "reading".startswith
+                )
             ),
-            [
-                ["admin", "domain.*", "data1", "read"],
-                ["user", "domain.1", "data2", "read"],
-            ],
+            sorted(
+                [
+                    ["admin", "domain.*", "data1", "read"],
+                    ["user", "domain.1", "data2", "read"],
+                    ["user", "domain.*", "data3", "read"],
+                ]
+            ),
         )
 
     def test_modify_policy_api(self):

--- a/tests/test_rbac_api.py
+++ b/tests/test_rbac_api.py
@@ -233,6 +233,43 @@ class TestRbacApi(TestCaseBase):
         )
         self.assertEqual(e.get_implicit_permissions_for_user("bob", "domain1"), [])
 
+    def test_enforce_implicit_permissions_api_with_domain_matching_function(self):
+
+        e = self.get_enforcer(
+            get_examples("rbac_with_domain_and_policy_pattern_model.conf"),
+            get_examples("rbac_with_domain_and_policy_pattern_policy.csv"),
+        )
+
+        e.get_role_manager().add_domain_matching_func(casbin.util.key_match2_func)
+
+        self.assertEqual(
+            e.get_implicit_permissions_for_user("alice", "domain.3"),
+            [["user", "domain.*", "data3", "read"]],
+        )
+
+        self.assertEqual(
+            e.get_implicit_permissions_for_user("alice", "domain.1"),
+            [
+                ["user", "domain.*", "data3", "read"],
+                ["user", "domain.1", "data2", "read"],
+                ["user", "domain.1", "data2", "write"],
+            ],
+        )
+
+        self.assertEqual(
+            e.get_implicit_permissions_for_user("bob", "domain.3"),
+            [["admin", "domain.*", "data1", "read"]],
+        )
+
+        self.assertEqual(
+            e.get_implicit_permissions_for_user("bob", "domain.2"),
+            [],
+        )
+
+        self.assertEqual(
+            sorted(e.get_implicit_permissions_for_user("bob", "domain.1")), []
+        )
+
     def test_enforce_implicit_permissions_api_with_domain_ignore_domain_policies_filter(
         self,
     ):


### PR DESCRIPTION
Fix: https://github.com/casbin/pycasbin/issues/227

Signed-off-by: timabilov <timabilov33@gmail.com>