### PR TITLE
fix: different behavior of glob_match from other casbin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 simpleeval >= 0.9.11
-wcmatch >= 8.1.2

--- a/tests/util/test_builtin_operators.py
+++ b/tests/util/test_builtin_operators.py
@@ -200,17 +200,55 @@ class TestBuiltinOperators(TestCase):
 
     def test_glob_match2(self):
         # add missing tests from Go to Python
-        self.assertFalse(util.glob_match_func("/foo", "*/foo"))  # different from Go
-        self.assertFalse(util.glob_match_func("/foo", "*/foo*"))  # different from Go
+        self.assertTrue(util.glob_match_func("/foo", "*/foo"))
+        self.assertTrue(util.glob_match_func("/foo", "*/foo*"))
         self.assertFalse(util.glob_match_func("/foo", "*/foo/*"))
         self.assertFalse(util.glob_match_func("/foo/bar", "*/foo"))
         self.assertFalse(util.glob_match_func("/foo/bar", "*/foo*"))
-        self.assertFalse(
-            util.glob_match_func("/foo/bar", "*/foo/*")
-        )  # different from Go
+        self.assertTrue(util.glob_match_func("/foo/bar", "*/foo/*"))
         self.assertFalse(util.glob_match_func("/foobar", "*/foo"))
-        self.assertFalse(util.glob_match_func("/foobar", "*/foo*"))  # different from Go
+        self.assertTrue(util.glob_match_func("/foobar", "*/foo*"))
         self.assertFalse(util.glob_match_func("/foobar", "*/foo/*"))
+
+    def test_glob_match3(self):
+        # add more tests for glob_match
+        # test ?
+        self.assertTrue(util.glob_match_func("/f", "/?"))
+        self.assertTrue(util.glob_match_func("/foobar", "/foo?ar"))
+        self.assertFalse(util.glob_match_func("/fooar", "/foo?ar"))
+        self.assertTrue(util.glob_match_func("/foobbar", "/foo??ar"))
+        self.assertTrue(util.glob_match_func("/foobbbbar", "/foo????ar"))
+        # test []
+        self.assertTrue(util.glob_match_func("/foobar", "/foo[bc]ar"))
+        self.assertFalse(util.glob_match_func("/fooaar", "/foo[bc]ar"))
+        self.assertFalse(util.glob_match_func("/foodar", "/foo[bc]ar"))
+        self.assertTrue(util.glob_match_func("/foobar", "/foo[b-b]ar"))
+        self.assertFalse(util.glob_match_func("/fooaar", "/foo[b-c]ar"))
+        self.assertTrue(util.glob_match_func("/foobar", "/foo[b-c]ar"))
+        self.assertTrue(util.glob_match_func("/foocar", "/foo[b-c]ar"))
+        self.assertFalse(util.glob_match_func("/foodar", "/foo[b-c]ar"))
+        # test ^ and !
+        self.assertTrue(util.glob_match_func("/foo1ar", "/foo[!234]ar"))
+        self.assertFalse(util.glob_match_func("/foo3ar", "/foo[!234]ar"))
+        self.assertTrue(util.glob_match_func("/foo5ar", "/foo[!234]ar"))
+        self.assertTrue(util.glob_match_func("/foo1ar", "/foo[!2-5]ar"))
+        self.assertFalse(util.glob_match_func("/foo2ar", "/foo[!2-5]ar"))
+        self.assertTrue(util.glob_match_func("/foo1ar", "/foo[^234]ar"))
+        self.assertFalse(util.glob_match_func("/foo3ar", "/foo[^234]ar"))
+        self.assertTrue(util.glob_match_func("/foo5ar", "/foo[^234]ar"))
+        self.assertTrue(util.glob_match_func("/foo1ar", "/foo[^2-5]ar"))
+        self.assertFalse(util.glob_match_func("/foo2ar", "/foo[^2-5]ar"))
+        # test \\
+        self.assertTrue(util.glob_match_func("\\", "\\\\"))
+        self.assertTrue(util.glob_match_func("/a", "/\\a"))
+        self.assertTrue(util.glob_match_func("/*", "/\\*"))
+        self.assertFalse(util.glob_match_func("a", "\\?"))
+        self.assertTrue(util.glob_match_func("?", "\\?"))
+        self.assertTrue(util.glob_match_func("\n", "\n"))
+        self.assertFalse(util.glob_match_func("\n", "\\n"))
+        self.assertTrue(util.glob_match_func("[", "\\["))
+        self.assertTrue(util.glob_match_func("*", "\\*"))
+        self.assertTrue(util.glob_match_func("\\*", "\\\\\\*"))
 
     def test_ip_match(self):
         self.assertTrue(util.ip_match_func("192.168.2.123", "192.168.2.0/24"))

--- a/tests/util/test_builtin_operators.py
+++ b/tests/util/test_builtin_operators.py
@@ -123,7 +123,15 @@ class TestBuiltinOperators(TestCase):
         self.assertFalse(util.glob_match_func("/foobar", "/foo"))
         self.assertTrue(util.glob_match_func("/foobar", "/foo*"))
         self.assertFalse(util.glob_match_func("/foobar", "/foo/*"))
-
+        self.assertTrue(util.glob_match_func("/foo", "*/foo"))
+        self.assertTrue(util.glob_match_func("/foo", "*/foo*"))
+        self.assertFalse(util.glob_match_func("/foo", "*/foo/*"))
+        self.assertFalse(util.glob_match_func("/foo/bar", "*/foo"))
+        self.assertFalse(util.glob_match_func("/foo/bar", "*/foo*"))
+        self.assertTrue(util.glob_match_func("/foo/bar", "*/foo/*"))
+        self.assertFalse(util.glob_match_func("/foobar", "*/foo"))
+        self.assertTrue(util.glob_match_func("/foobar", "*/foo*"))
+        self.assertFalse(util.glob_match_func("/foobar", "*/foo/*"))
         self.assertFalse(util.glob_match_func("/prefix/foo", "*/foo"))
         self.assertFalse(util.glob_match_func("/prefix/foo", "*/foo*"))
         self.assertFalse(util.glob_match_func("/prefix/foo", "*/foo/*"))
@@ -133,7 +141,6 @@ class TestBuiltinOperators(TestCase):
         self.assertFalse(util.glob_match_func("/prefix/foobar", "*/foo"))
         self.assertFalse(util.glob_match_func("/prefix/foobar", "*/foo*"))
         self.assertFalse(util.glob_match_func("/prefix/foobar", "*/foo/*"))
-
         self.assertFalse(util.glob_match_func("/prefix/subprefix/foo", "*/foo"))
         self.assertFalse(util.glob_match_func("/prefix/subprefix/foo", "*/foo*"))
         self.assertFalse(util.glob_match_func("/prefix/subprefix/foo", "*/foo/*"))
@@ -144,27 +151,11 @@ class TestBuiltinOperators(TestCase):
         self.assertFalse(util.glob_match_func("/prefix/subprefix/foobar", "*/foo*"))
         self.assertFalse(util.glob_match_func("/prefix/subprefix/foobar", "*/foo/*"))
 
-    def test_glob_match2(self):
-        # add missing tests from Go to Python
-        self.assertTrue(util.glob_match_func("/foo", "*/foo"))
-        self.assertTrue(util.glob_match_func("/foo", "*/foo*"))
-        self.assertFalse(util.glob_match_func("/foo", "*/foo/*"))
-        self.assertFalse(util.glob_match_func("/foo/bar", "*/foo"))
-        self.assertFalse(util.glob_match_func("/foo/bar", "*/foo*"))
-        self.assertTrue(util.glob_match_func("/foo/bar", "*/foo/*"))
-        self.assertFalse(util.glob_match_func("/foobar", "*/foo"))
-        self.assertTrue(util.glob_match_func("/foobar", "*/foo*"))
-        self.assertFalse(util.glob_match_func("/foobar", "*/foo/*"))
-
-    def test_glob_match3(self):
-        # add more tests for glob_match
-        # test ?
         self.assertTrue(util.glob_match_func("/f", "/?"))
         self.assertTrue(util.glob_match_func("/foobar", "/foo?ar"))
         self.assertFalse(util.glob_match_func("/fooar", "/foo?ar"))
         self.assertTrue(util.glob_match_func("/foobbar", "/foo??ar"))
         self.assertTrue(util.glob_match_func("/foobbbbar", "/foo????ar"))
-        # test []
         self.assertTrue(util.glob_match_func("/foobar", "/foo[bc]ar"))
         self.assertFalse(util.glob_match_func("/fooaar", "/foo[bc]ar"))
         self.assertFalse(util.glob_match_func("/foodar", "/foo[bc]ar"))
@@ -173,7 +164,6 @@ class TestBuiltinOperators(TestCase):
         self.assertTrue(util.glob_match_func("/foobar", "/foo[b-c]ar"))
         self.assertTrue(util.glob_match_func("/foocar", "/foo[b-c]ar"))
         self.assertFalse(util.glob_match_func("/foodar", "/foo[b-c]ar"))
-        # test ^ and !
         self.assertTrue(util.glob_match_func("/foo1ar", "/foo[!234]ar"))
         self.assertFalse(util.glob_match_func("/foo3ar", "/foo[!234]ar"))
         self.assertTrue(util.glob_match_func("/foo5ar", "/foo[!234]ar"))
@@ -184,7 +174,7 @@ class TestBuiltinOperators(TestCase):
         self.assertTrue(util.glob_match_func("/foo5ar", "/foo[^234]ar"))
         self.assertTrue(util.glob_match_func("/foo1ar", "/foo[^2-5]ar"))
         self.assertFalse(util.glob_match_func("/foo2ar", "/foo[^2-5]ar"))
-        # test \\
+
         self.assertTrue(util.glob_match_func("\\", "\\\\"))
         self.assertTrue(util.glob_match_func("/a", "/\\a"))
         self.assertTrue(util.glob_match_func("/*", "/\\*"))


### PR DESCRIPTION
Fix: #148 
![$CHOLE(OJX@FU71$Z57`M6](https://user-images.githubusercontent.com/75596353/165298802-1e7ec541-8fb3-4ca2-8eb7-1a6e9e71da8b.png)
Reimplement the glob_match