### PR TITLE
fix: allow permissions management to use additional p-types

### DIFF
--- a/casbin/enforcer.py
+++ b/casbin/enforcer.py
@@ -170,26 +170,9 @@ class Enforcer(ManagementEnforcer):
 
         filter_policy_dom: bool - For given *domain*, policies will be filtered by domain as well. Default = True
         """
-        roles = self.get_implicit_roles_for_user(user, domain)
+        return self.get_named_implicit_permissions_for_user("p", user, domain, filter_policy_dom)
 
-        roles.insert(0, user)
-
-        res = []
-
-        # policy domain should be matched by domain_match_fn of DomainManager
-        domain_matching_func = self.get_role_manager().domain_matching_func
-        if domain and domain_matching_func != None:
-            domain = partial(domain_matching_func, domain)
-
-        for role in roles:
-            permissions = self.get_permissions_for_user_in_domain(role, domain if filter_policy_dom else "")
-            res.extend(permissions)
-
-        return res
-
-    def get_implicit_permissions_for_user_by_named_policy(
-        self, ptype, user, domain="", filter_policy_dom=True
-    ):
+    def get_named_implicit_permissions_for_user(self, ptype, user, domain="", filter_policy_dom=True):
         """
         gets implicit permissions for a user or role by named policy.
         Compared to get_permissions_for_user(), this function retrieves permissions for inherited roles.
@@ -219,7 +202,7 @@ class Enforcer(ManagementEnforcer):
             domain = partial(domain_matching_func, domain)
 
         for role in roles:
-            permissions = self.get_permissions_for_user_by_named_policy_in_domain(
+            permissions = self.get_named_permissions_for_user_in_domain(
                 ptype, role, domain if filter_policy_dom else ""
             )
             res.extend(permissions)
@@ -274,8 +257,8 @@ class Enforcer(ManagementEnforcer):
 
     def get_permissions_for_user_in_domain(self, user, domain):
         """gets permissions for a user or role inside domain."""
-        return self.get_filtered_policy(0, user, domain)
+        return self.get_named_permissions_for_user_in_domain("p", user, domain)
 
-    def get_permissions_for_user_by_named_policy_in_domain(self, ptype, user, domain):
+    def get_named_permissions_for_user_in_domain(self, ptype, user, domain):
         """gets permissions for a user or role with named policy inside domain."""
         return self.get_filtered_named_policy(ptype, 0, user, domain)

--- a/casbin/enforcer.py
+++ b/casbin/enforcer.py
@@ -191,6 +191,45 @@ class Enforcer(ManagementEnforcer):
 
         return res
 
+    def get_implicit_permissions_for_user_by_named_policy(
+        self, ptype, user, domain="", filter_policy_dom=True
+    ):
+        """
+        gets implicit permissions for a user or role by named policy.
+        Compared to get_permissions_for_user(), this function retrieves permissions for inherited roles.
+        For example:
+        p, admin, data1, read
+        p, alice, data2, read
+        g, alice, admin
+
+        get_permissions_for_user("alice") can only get: [["alice", "data2", "read"]].
+        But get_implicit_permissions_for_user("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
+
+        For given domain policies are filtered by corresponding domain matching function of DomainManager
+        Inherited roles can be matched by domain. For domain neutral policies set:
+         filter_policy_dom = False
+
+        filter_policy_dom: bool - For given *domain*, policies will be filtered by domain as well. Default = True
+        """
+        roles = self.get_implicit_roles_for_user(user, domain)
+
+        roles.insert(0, user)
+
+        res = []
+
+        # policy domain should be matched by domain_match_fn of DomainManager
+        domain_matching_func = self.get_role_manager().domain_matching_func
+        if domain and domain_matching_func != None:
+            domain = partial(domain_matching_func, domain)
+
+        for role in roles:
+            permissions = self.get_permissions_for_user_by_named_policy_in_domain(
+                ptype, role, domain if filter_policy_dom else ""
+            )
+            res.extend(permissions)
+
+        return res
+
     def get_implicit_users_for_permission(self, *permission):
         """
         gets implicit users for a permission.
@@ -240,3 +279,7 @@ class Enforcer(ManagementEnforcer):
     def get_permissions_for_user_in_domain(self, user, domain):
         """gets permissions for a user or role inside domain."""
         return self.get_filtered_policy(0, user, domain)
+
+    def get_permissions_for_user_by_named_policy_in_domain(self, ptype, user, domain):
+        """gets permissions for a user or role with named policy inside domain."""
+        return self.get_filtered_named_policy(ptype, 0, user, domain)

--- a/casbin/synced_enforcer.py
+++ b/casbin/synced_enforcer.py
@@ -464,9 +464,7 @@ class SyncedEnforcer:
         with self._rl:
             return self._e.get_implicit_permissions_for_user(user, *domain, filter_policy_dom=filter_policy_dom)
 
-    def get_implicit_permissions_for_user_by_named_policy(
-        self, ptype, user, *domain, filter_policy_dom=True
-    ):
+    def get_named_implicit_permissions_for_user(self, ptype, user, *domain, filter_policy_dom=True):
         """
         gets implicit permissions for a user or role by named policy.
         Compared to get_permissions_for_user(), this function retrieves permissions for inherited roles.
@@ -479,7 +477,7 @@ class SyncedEnforcer:
         But get_implicit_permissions_for_user("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
         """
         with self._rl:
-            return self._e.get_implicit_permissions_for_user_by_named_policy(
+            return self._e.get_named_implicit_permissions_for_user(
                 ptype, user, *domain, filter_policy_dom=filter_policy_dom
             )
 
@@ -524,12 +522,10 @@ class SyncedEnforcer:
         with self._rl:
             return self._e.get_permissions_for_user_in_domain(user, domain)
 
-    def get_permissions_for_user_by_named_policy_in_domain(self, ptype, user, domain):
+    def get_named_permissions_for_user_in_domain(self, ptype, user, domain):
         """gets permissions for a user or role by named policy inside domain."""
         with self._rl:
-            return self._e.get_permissions_for_user_by_named_policy_in_domain(
-                ptype, user, domain
-            )
+            return self._e.get_named_permissions_for_user_in_domain(ptype, user, domain)
 
     def enable_auto_build_role_links(self, auto_build_role_links):
         """controls whether to rebuild the role inheritance relations when a role is added or deleted."""

--- a/casbin/synced_enforcer.py
+++ b/casbin/synced_enforcer.py
@@ -474,6 +474,25 @@ class SyncedEnforcer:
                 user, *domain, filter_policy_dom=filter_policy_dom
             )
 
+    def get_implicit_permissions_for_user_by_named_policy(
+        self, ptype, user, *domain, filter_policy_dom=True
+    ):
+        """
+        gets implicit permissions for a user or role by named policy.
+        Compared to get_permissions_for_user(), this function retrieves permissions for inherited roles.
+        For example:
+        p, admin, data1, read
+        p, alice, data2, read
+        g, alice, admin
+
+        get_permissions_for_user("alice") can only get: [["alice", "data2", "read"]].
+        But get_implicit_permissions_for_user("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
+        """
+        with self._rl:
+            return self._e.get_implicit_permissions_for_user_by_named_policy(
+                ptype, user, *domain, filter_policy_dom=filter_policy_dom
+            )
+
     def get_implicit_users_for_permission(self, *permission):
         """
         gets implicit users for a permission.
@@ -514,6 +533,13 @@ class SyncedEnforcer:
         """gets permissions for a user or role inside domain."""
         with self._rl:
             return self._e.get_permissions_for_user_in_domain(user, domain)
+
+    def get_permissions_for_user_by_named_policy_in_domain(self, ptype, user, domain):
+        """gets permissions for a user or role by named policy inside domain."""
+        with self._rl:
+            return self._e.get_permissions_for_user_by_named_policy_in_domain(
+                ptype, user, domain
+            )
 
     def enable_auto_build_role_links(self, auto_build_role_links):
         """controls whether to rebuild the role inheritance relations when a role is added or deleted."""

--- a/examples/rbac_with_multiple_policy_model.conf
+++ b/examples/rbac_with_multiple_policy_model.conf
@@ -1,0 +1,16 @@
+[request_definition]
+r = user, thing, action
+
+[policy_definition]
+p = role, thing, action
+p2 = role, action
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.user, p.role) && r.thing == p.thing && r.action == p.action
+m2 = g(r.user, p2.role) && r.action == p.action
+
+[role_definition]
+g = _,_

--- a/examples/rbac_with_multiple_policy_policy.csv
+++ b/examples/rbac_with_multiple_policy_policy.csv
@@ -1,0 +1,8 @@
+p, user, /data, GET
+p, admin, /data, POST
+
+p2, user, view
+p2, admin, create
+
+g, admin, user
+g, alice, admin

--- a/tests/test_rbac_api.py
+++ b/tests/test_rbac_api.py
@@ -222,6 +222,31 @@ class TestRbacApi(TestCaseBase):
             sorted([["bob", "data2", "write"]]),
         )
 
+    def test_enforce_implicit_permissions_api_with_multiple_policy(self):
+        e = self.get_enforcer(
+            get_examples("rbac_with_multiple_policy_model.conf"),
+            get_examples("rbac_with_multiple_policy_policy.csv"),
+        )
+
+        self.assertEqual(
+            sorted(e.get_implicit_permissions_for_user_by_named_policy("p", "alice")),
+            sorted(
+                [
+                    ["user", "/data", "GET"],
+                    ["admin", "/data", "POST"],
+                ]
+            ),
+        )
+        self.assertEqual(
+            sorted(e.get_implicit_permissions_for_user_by_named_policy("p2", "alice")),
+            sorted(
+                [
+                    ["user", "view"],
+                    ["admin", "create"],
+                ]
+            ),
+        )
+
     def test_enforce_implicit_permissions_api_with_domain(self):
         e = self.get_enforcer(
             get_examples("rbac_with_domains_model.conf"),

--- a/tests/test_rbac_api.py
+++ b/tests/test_rbac_api.py
@@ -211,7 +211,7 @@ class TestRbacApi(TestCaseBase):
         )
 
         self.assertEqual(
-            sorted(e.get_implicit_permissions_for_user_by_named_policy("p", "alice")),
+            sorted(e.get_named_implicit_permissions_for_user("p", "alice")),
             sorted(
                 [
                     ["user", "/data", "GET"],
@@ -220,7 +220,7 @@ class TestRbacApi(TestCaseBase):
             ),
         )
         self.assertEqual(
-            sorted(e.get_implicit_permissions_for_user_by_named_policy("p2", "alice")),
+            sorted(e.get_named_implicit_permissions_for_user("p2", "alice")),
             sorted(
                 [
                     ["user", "view"],


### PR DESCRIPTION
Fix: #253 
fix the issue by add get_implicit_permissions_for_user_by_named_policy(), 
so user can get permissions with named ptypes.