### PR TITLE
fix: add dependency for benchmark

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,4 @@
 -r requirements.txt
 black==21.6b0
+pytest==7.0.1
+pytest-benchmark==3.4.1


### PR DESCRIPTION
Without pytest and pytest-benchmark, can't run benchmark locally