### PR TITLE
fix: catch exceptions in synced enforcer thread

### DIFF
--- a/casbin/synced_enforcer.py
+++ b/casbin/synced_enforcer.py
@@ -55,7 +55,10 @@ class SyncedEnforcer:
     def _auto_load_policy(self, interval):
         while self.is_auto_loading_running():
             time.sleep(interval)
-            self.load_policy()
+            try:
+                self.load_policy()
+            except Exception as e:
+                self.logger.error(str(e))
 
     def start_auto_load_policy(self, interval):
         """starts a thread that will call load_policy every interval seconds"""


### PR DESCRIPTION
At present if an exception occurs in the auto loader thread it kills the thread with no way of restarting it.  This means that even a recoverable error will kill the thread permanently - we've seen this on our own app were we temporarily lose connectivity with the DB.  Once connectivity is restored the auto loader is broken because the thread has died, forcing us to restart our app.