### PR TITLE
fix: fix bug in autoloader error handling

### DIFF
--- a/casbin/synced_enforcer.py
+++ b/casbin/synced_enforcer.py
@@ -58,7 +58,7 @@ class SyncedEnforcer:
             try:
                 self.load_policy()
             except Exception as e:
-                self.logger.error(str(e))
+                self._e.logger.error(repr(e))
 
     def start_auto_load_policy(self, interval):
         """starts a thread that will call load_policy every interval seconds"""

--- a/casbin/synced_enforcer.py
+++ b/casbin/synced_enforcer.py
@@ -55,7 +55,10 @@ class SyncedEnforcer:
     def _auto_load_policy(self, interval):
         while self.is_auto_loading_running():
             time.sleep(interval)
-            self.load_policy()
+            try:
+                self.load_policy()
+            except Exception as e:
+                self.logger.error(str(e))
 
     def start_auto_load_policy(self, interval):
         """starts a thread that will call load_policy every interval seconds"""


### PR DESCRIPTION
Fixes a bug in (my own) https://github.com/casbin/pycasbin/pull/272 - syncedEnforcer doesn't have its own logger, it needs to use the Enforcer's logger.