### PR TITLE
fix: support escaping comma inside quote in load_policy_line()'s CSV parsing

### DIFF
--- a/casbin/persist/adapter.py
+++ b/casbin/persist/adapter.py
@@ -22,7 +22,25 @@ def load_policy_line(line, model):
     if line[:1] == "#":
         return
 
-    tokens = [token.strip() for token in line.split(",")]
+    stack = []
+    tokens = []
+    for c in line:
+        if c == "[":
+            stack.append(c)
+            tokens[-1] += "["
+        elif c == "]":
+            stack.pop()
+            tokens[-1] += "]"
+        elif c == "," and len(stack) == 0:
+            tokens.append("")
+        else:
+            if len(tokens) == 0:
+                tokens.append(c)
+            else:
+                tokens[-1] += c
+
+    tokens = [x.strip() for x in tokens]
+
     key = tokens[0]
     sec = key[0]
 


### PR DESCRIPTION
Fix: https://github.com/casbin/pycasbin/issues/291

<img width="696" alt="1680340052881" src="https://user-images.githubusercontent.com/84124955/229276928-aa2e8d5a-4d7d-46da-a666-cb840b807701.png">
