### PR TITLE
fix: Stop including README as top-level data file in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,4 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    data_files=[desc_file],
 )


### PR DESCRIPTION
Fix: https://github.com/casbin/pycasbin/issues/295

Including the `README.md` as a top-level data file is unconventional and can interfere with other packages if they also accidentally include their `README.md`: installing both packages leads to the second one overwriting the `README.md` of the first one. (A lot of the casbin python packages interfere with each other like this.)

The contents of the README is available as the package's long description, which is included in its `METADATA` file.

In addition to that problem, running `python setup.py bdist_wheel` results in a warning, tangentially referencing this problem:

```
warning: install_data: setup script did not provide a directory for 'README.md' -- installing right in 'build/bdist.macosx-11.4-arm64/wheel/casbin-1.18.2.data/data'
```

This fixes (partially) #295, for this repository.