### PR TITLE
fix: Exclude tests from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
         "access control",
         "permission",
     ],
-    packages=setuptools.find_packages(exclude=("tests",)),
+    packages=setuptools.find_packages(exclude=("tests", "tests.*")),
     install_requires=install_requires,
     python_requires=">=3.3",
     license="Apache 2.0",


### PR DESCRIPTION
The wheels include the tests, due to the `find_packages` exclusion being subtle: it is a full package path glob, not just a prefix/parent package exclusion. This makes the appropriate adjustment to the `find_packages(exclude=...)` call to ensure they're not included.

See the "Important" note in https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-simple-packages

```
curl -O https://files.pythonhosted.org/packages/a8/02/b6c6de2524add783af7be9b057baf8dc1cda62b4aa5cd8b7ea2ede500658/casbin-1.18.2-py3-none-any.whl
unzip -l casbin-1.18.2-py3-none-any.whl
#> ...
#>       637  04-06-2023 17:12   tests/benchmarks/__init__.py
#>      2882  04-06-2023 17:12   tests/benchmarks/benchmark_management_api.py
#> ...
#> ---------                     -------
#>    270392                     60 files
```

After this patch, the `unzip -l` on a built wheel includes none of the `tests`. The uncompressed package is only only 206607 bytes (64KB smaller, -24%) and 46 files.