### PR TITLE
feat: add auto_notify_watcher to core enforcer

### DIFF
--- a/casbin/core_enforcer.py
+++ b/casbin/core_enforcer.py
@@ -50,6 +50,7 @@ class CoreEnforcer:
     enabled = False
     auto_save = False
     auto_build_role_links = False
+    auto_notify_watcher = False
 
     def __init__(self, model=None, adapter=None):
         self.logger = logging.getLogger(__name__)
@@ -106,6 +107,7 @@ class CoreEnforcer:
         self.enabled = True
         self.auto_save = True
         self.auto_build_role_links = True
+        self.auto_notify_watcher = True
 
         self.init_rm_map()
 
@@ -282,6 +284,10 @@ class CoreEnforcer:
     def enable_auto_build_role_links(self, auto_build_role_links):
         """controls whether to rebuild the role inheritance relations when a role is added or deleted."""
         self.auto_build_role_links = auto_build_role_links
+
+    def enable_auto_notify_watcher(self, auto_notify_watcher):
+        """controls whether to save a policy rule automatically notify the watcher when it is added or removed."""
+        self.auto_notify_watcher = auto_notify_watcher
 
     def build_role_links(self):
         """manually rebuild the role inheritance relations."""

--- a/casbin/internal_enforcer.py
+++ b/casbin/internal_enforcer.py
@@ -30,7 +30,7 @@ class InternalEnforcer(CoreEnforcer):
             if self.adapter.add_policy(sec, ptype, rule) is False:
                 return False
 
-            if self.watcher:
+            if self.watcher and self.auto_notify_watcher:
                 if callable(getattr(self.watcher, "update_for_add_policy", None)):
                     self.watcher.update_for_add_policy(sec, ptype, rule)
                 else:
@@ -51,7 +51,7 @@ class InternalEnforcer(CoreEnforcer):
             if self.adapter.add_policies(sec, ptype, rules) is False:
                 return False
 
-            if self.watcher:
+            if self.watcher and self.auto_notify_watcher:
                 if callable(getattr(self.watcher, "update_for_add_policies", None)):
                     self.watcher.update_for_add_policies(sec, ptype, rules)
                 else:
@@ -71,7 +71,7 @@ class InternalEnforcer(CoreEnforcer):
             if self.adapter.update_policy(sec, ptype, old_rule, new_rule) is False:
                 return False
 
-            if self.watcher:
+            if self.watcher and self.auto_notify_watcher:
                 self.watcher.update()
 
         return rule_updated
@@ -88,7 +88,7 @@ class InternalEnforcer(CoreEnforcer):
             if self.adapter.update_policies(sec, ptype, old_rules, new_rules) is False:
                 return False
 
-            if self.watcher:
+            if self.watcher and self.auto_notify_watcher:
                 self.watcher.update()
 
         return rules_updated
@@ -114,7 +114,7 @@ class InternalEnforcer(CoreEnforcer):
             return is_rule_changed
         if sec == "g":
             self.build_role_links()
-        if self.watcher:
+        if self.watcher and self.auto_notify_watcher:
             self.watcher.update()
         return is_rule_changed
 
@@ -128,7 +128,7 @@ class InternalEnforcer(CoreEnforcer):
             if self.adapter.remove_policy(sec, ptype, rule) is False:
                 return False
 
-            if self.watcher:
+            if self.watcher and self.auto_notify_watcher:
                 if callable(getattr(self.watcher, "update_for_remove_policy", None)):
                     self.watcher.update_for_remove_policy(sec, ptype, rule)
                 else:
@@ -149,7 +149,7 @@ class InternalEnforcer(CoreEnforcer):
             if self.adapter.remove_policies(sec, ptype, rules) is False:
                 return False
 
-            if self.watcher:
+            if self.watcher and self.auto_notify_watcher:
                 if callable(getattr(self.watcher, "update_for_remove_policies", None)):
                     self.watcher.update_for_remove_policies(sec, ptype, rules)
                 else:
@@ -167,7 +167,7 @@ class InternalEnforcer(CoreEnforcer):
             if self.adapter.remove_filtered_policy(sec, ptype, field_index, *field_values) is False:
                 return False
 
-            if self.watcher:
+            if self.watcher and self.auto_notify_watcher:
                 if callable(getattr(self.watcher, "update_for_remove_filtered_policy", None)):
                     self.watcher.update_for_remove_filtered_policy(sec, ptype, field_index, *field_values)
                 else:
@@ -185,7 +185,7 @@ class InternalEnforcer(CoreEnforcer):
             if self.adapter.remove_filtered_policy(sec, ptype, field_index, *field_values) is False:
                 return False
 
-            if self.watcher:
+            if self.watcher and self.auto_notify_watcher:
                 self.watcher.update()
 
         return rule_removed

--- a/tests/test_watcher_ex.py
+++ b/tests/test_watcher_ex.py
@@ -1,0 +1,190 @@
+# Copyright 2023 The casbin Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import casbin
+from tests.test_enforcer import get_examples, TestCaseBase
+
+
+class SampleWatcher:
+    def __init__(self):
+        self.callback = None
+        self.notify_message = None
+
+    def close(self):
+        pass
+
+    def set_update_callback(self, callback):
+        """
+        sets the callback function to be called when the policy is updated
+        :param callable callback: callback(event)
+            - event: event received from the rabbitmq
+        :return:
+        """
+        self.callback = callback
+
+    def update(self, msg):
+        """
+        update the policy
+        """
+        self.notify_message = msg
+        return True
+
+    def update_for_add_policy(self, section, ptype, *params):
+        """
+        update for add policy
+        :param section: section
+        :param ptype:   policy type
+        :param params:  other params
+        :return:    True if updated
+        """
+        message = "called add policy"
+        return self.update(message)
+
+    def update_for_remove_policy(self, section, ptype, *params):
+        """
+        update for remove policy
+        :param section: section
+        :param ptype:   policy type
+        :param params:  other params
+        :return:    True if updated
+        """
+        message = "called remove policy"
+        return self.update(message)
+
+    def update_for_remove_filtered_policy(self, section, ptype, field_index, *params):
+        """
+        update for remove filtered policy
+        :param section: section
+        :param ptype:   policy type
+        :param field_index: field index
+        :param params: other params
+        :return:
+        """
+        message = "called remove filtered policy"
+        return self.update(message)
+
+    def update_for_save_policy(self, model: casbin.Model):
+        """
+        update for save policy
+        :param model: casbin model
+        :return:
+        """
+        message = "called save policy"
+        return self.update(message)
+
+    def update_for_add_policies(self, section, ptype, *params):
+        """
+        update for add policies
+        :param section: section
+        :param ptype:   policy type
+        :param params:  other params
+        :return:
+        """
+        message = "called add policies"
+        return self.update(message)
+
+    def update_for_remove_policies(self, section, ptype, *params):
+        """
+        update for remove policies
+        :param section: section
+        :param ptype:   policy type
+        :param params:  other params
+        :return:
+        """
+        message = "called remove policies"
+        return self.update(message)
+
+    def start_watch(self):
+        """
+        starts the watch thread
+        :return:
+        """
+        pass
+
+
+class TestWatcherEx(TestCaseBase):
+    def get_enforcer(self, model=None, adapter=None):
+        return casbin.Enforcer(
+            model,
+            adapter,
+        )
+
+    def test_auto_notify_enabled(self):
+        e = self.get_enforcer(
+            get_examples("basic_model.conf"),
+            get_examples("basic_policy.csv"),
+        )
+        w = SampleWatcher()
+        e.set_watcher(w)
+        e.enable_auto_notify_watcher(True)
+
+        e.save_policy()
+        self.assertEqual(w.notify_message, "called save policy")
+
+        e.add_policy("admin", "data1", "read")
+        self.assertEqual(w.notify_message, "called add policy")
+
+        e.remove_policy("admin", "data1", "read")
+        self.assertEqual(w.notify_message, "called remove policy")
+
+        e.remove_filtered_policy(1, "data1")
+        self.assertEqual(w.notify_message, "called remove filtered policy")
+
+        rules = [
+            ["jack", "data4", "read"],
+            ["katy", "data4", "write"],
+            ["leyo", "data4", "read"],
+            ["ham", "data4", "write"],
+        ]
+        e.add_policies(rules)
+        self.assertEqual(w.notify_message, "called add policies")
+
+        e.remove_policies(rules)
+        self.assertEqual(w.notify_message, "called remove policies")
+
+    def test_auto_notify_disabled(self):
+        e = self.get_enforcer(
+            get_examples("basic_model.conf"),
+            get_examples("basic_policy.csv"),
+        )
+        w = SampleWatcher()
+        e.set_watcher(w)
+        e.enable_auto_notify_watcher(False)
+
+        e.save_policy()
+        self.assertEqual(w.notify_message, "called save policy")
+
+        w.notify_message = None
+
+        e.add_policy("admin", "data1", "read")
+        self.assertEqual(w.notify_message, None)
+
+        e.remove_policy("admin", "data1", "read")
+        self.assertEqual(w.notify_message, None)
+
+        e.remove_filtered_policy(1, "data1")
+        self.assertEqual(w.notify_message, None)
+
+        rules = [
+            ["jack", "data4", "read"],
+            ["katy", "data4", "write"],
+            ["leyo", "data4", "read"],
+            ["ham", "data4", "write"],
+        ]
+        e.add_policies(rules)
+        self.assertEqual(w.notify_message, None)
+
+        e.remove_policies(rules)
+        self.assertEqual(w.notify_message, None)
+

--- a/tests/test_watcher_ex.py
+++ b/tests/test_watcher_ex.py
@@ -187,4 +187,3 @@ class TestWatcherEx(TestCaseBase):
 
         e.remove_policies(rules)
         self.assertEqual(w.notify_message, None)
-


### PR DESCRIPTION
Add auto_notify_watcher to control whether to save a policy rule automatically notify the watcher when it is added or removed.
refer to: https://github.com/casbin/casbin/pull/366