### PR TITLE
fix: fix bug in add policy for priority effectors

### DIFF
--- a/casbin/model/policy.py
+++ b/casbin/model/policy.py
@@ -118,11 +118,12 @@ class Policy:
                         print(e)
 
                     if idx > idx_insert:
+                        tmp = assertion.policy[i]
                         assertion.policy[i] = assertion.policy[i - 1]
+                        assertion.policy[i - 1] = tmp
                     else:
                         break
 
-                assertion.policy[i] = rule
                 assertion.policy_map[DEFAULT_SEP.join(rule)] = i
 
             except Exception as e:


### PR DESCRIPTION
Fix: https://github.com/casbin/pycasbin/issues/310

**Description**:

Fixes a bug in assigning an index to a new policy was added when using the priority effector. 

The bug is that when we loop from range(i, 0, -1), i stops at 1 ( since range is exclusive for the end parameter ), and hence we cant assign a policy to index 0 in this logic ( in case the newly added policy indeed has the lowest priority )

I swapped it for a simpler logic that bubbles up the inserted policy to the correct index. 

**Related Issue:**
https://github.com/casbin/pycasbin/issues/310

**Tests:**

Ran - python3 -m unittest discover


```
..['alice']
..............Request: bob, data1, read ---> False
Request: bob, data1, write ---> False
Request: bob, data2, read ---> False
.............................................
----------------------------------------------------------------------
Ran 462 tests in 0.807s
```

OK
