### PR TITLE
fix: fix integer priority sorting

### DIFF
--- a/casbin/model/model.py
+++ b/casbin/model/model.py
@@ -124,7 +124,11 @@ class Model(Policy):
             if assertion.priority_index == -1:
                 continue
 
-            assertion.policy = sorted(assertion.policy, key=lambda x: x[assertion.priority_index])
+            assertion.policy = sorted(
+                assertion.policy,
+                key=lambda x: int(x[assertion.priority_index]) if x[assertion.priority_index].isdigit() else
+                x[assertion.priority_index]
+            )
 
             for i, policy in enumerate(assertion.policy):
                 assertion.policy_map[",".join(policy)] = i


### PR DESCRIPTION
Fix for #326. Fixes policy sorting with priorities if priorities are numbers.
