### PR TITLE
chore: semantic-release commits pyproject.toml

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,7 +16,7 @@
       "@semantic-release/git",
       {
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
-        "assets": ["CHANGELOG.md", "setup.py", "setup.cfg"]
+        "assets": ["CHANGELOG.md", "pyproject.toml"]
       }
     ]
   ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "casbin"
-version = "1.32.0"
+version = "1.33.0"
 authors = [
     {name = "TechLee", email = "techlee@qq.com"},
 ]


### PR DESCRIPTION
@leeqvip 
Ups! I forgot to add `pyproject.toml` to the assets of `@semantic-release/git`