### PR TITLE
fix: FastEnforcer not fast

### DIFF
--- a/casbin/fast_enforcer.py
+++ b/casbin/fast_enforcer.py
@@ -31,7 +31,7 @@ class FastEnforcer(Enforcer):
         """decides whether a "subject" can access a "object" with the operation "action",
         input parameters are usually: (sub, obj, act).
         """
-        if FastEnforcer._cache_key_order is None:
+        if self._cache_key_order is None:
             result, _ = self.enforce_ex(*rvals)
         else:
             keys = [rvals[x] for x in self._cache_key_order]

--- a/tests/test_fast_enforcer.py
+++ b/tests/test_fast_enforcer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import time
 from typing import Sequence
 from unittest import TestCase
 
@@ -35,6 +36,24 @@ class TestCaseBase(TestCase):
 
 
 class TestFastEnforcer(TestCaseBase):
+    def test_performance(self) -> None:
+        e1 = self.get_enforcer(
+            get_examples("performance/rbac_with_pattern_large_scale_model.conf"),
+            get_examples("performance/rbac_with_pattern_large_scale_policy.csv"),
+        )
+        e2 = self.get_enforcer(
+            get_examples("performance/rbac_with_pattern_large_scale_model.conf"),
+            get_examples("performance/rbac_with_pattern_large_scale_policy.csv"),
+            [2, 1],
+        )
+        s_e1 = time.perf_counter()
+        e1.enforce("alice", "data1", "read")
+        t_e1 = time.perf_counter() - s_e1
+        s_e2 = time.perf_counter()
+        e2.enforce("alice", "data1", "read")
+        t_e2 = time.perf_counter() - s_e2
+        assert t_e1 > t_e2 * 5
+
     def test_creates_proper_policy(self) -> None:
         e = self.get_enforcer(
             get_examples("basic_model.conf"),


### PR DESCRIPTION
## Description
The FastEnforcer class has a check to see if `FastEnforcer._cache_key_order` is None. If None, the enforcer does not use the `fast_policy_filter` which provides significant performance enhancements. This is likely a bug, as `FastEnforcer._cache_key_order` refers to the class variable, and not the current instance's value. `self._cache_key_order` should be checked instead.


## Related Issues
https://github.com/casbin/pycasbin/issues/336
https://github.com/casbin/pycasbin/issues/71