### PR TITLE
fix: field_index is incorrect in RBAC with domains mode (#345)

### DIFF
--- a/casbin/constant/constants.py
+++ b/casbin/constant/constants.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # Index constants
+ACTION_INDEX = "act"
 DOMAIN_INDEX = "dom"
 SUBJECT_INDEX = "sub"
 OBJECT_INDEX = "obj"

--- a/casbin/management_enforcer.py
+++ b/casbin/management_enforcer.py
@@ -27,7 +27,8 @@ class ManagementEnforcer(InternalEnforcer):
 
     def get_all_named_subjects(self, ptype):
         """gets the list of subjects that show up in the current named policy."""
-        return self.model.get_values_for_field_in_policy("p", ptype, 0)
+        field_index = self.model.get_field_index(ptype, "sub")
+        return self.model.get_values_for_field_in_policy("p", ptype, field_index)
 
     def get_all_objects(self):
         """gets the list of objects that show up in the current policy."""
@@ -35,7 +36,8 @@ class ManagementEnforcer(InternalEnforcer):
 
     def get_all_named_objects(self, ptype):
         """gets the list of objects that show up in the current named policy."""
-        return self.model.get_values_for_field_in_policy("p", ptype, 1)
+        field_index = self.model.get_field_index(ptype, "obj")
+        return self.model.get_values_for_field_in_policy("p", ptype, field_index)
 
     def get_all_actions(self):
         """gets the list of actions that show up in the current policy."""
@@ -43,7 +45,8 @@ class ManagementEnforcer(InternalEnforcer):
 
     def get_all_named_actions(self, ptype):
         """gets the list of actions that show up in the current named policy."""
-        return self.model.get_values_for_field_in_policy("p", ptype, 2)
+        field_index = self.model.get_field_index(ptype, "act")
+        return self.model.get_values_for_field_in_policy("p", ptype, field_index)
 
     def get_all_roles(self):
         """gets the list of roles that show up in the current named policy."""

--- a/casbin/management_enforcer.py
+++ b/casbin/management_enforcer.py
@@ -14,6 +14,7 @@
 
 from casbin.internal_enforcer import InternalEnforcer
 from casbin.model.policy_op import PolicyOp
+from casbin.constant.constants import ACTION_INDEX, SUBJECT_INDEX, OBJECT_INDEX
 
 
 class ManagementEnforcer(InternalEnforcer):
@@ -27,7 +28,7 @@ class ManagementEnforcer(InternalEnforcer):
 
     def get_all_named_subjects(self, ptype):
         """gets the list of subjects that show up in the current named policy."""
-        field_index = self.model.get_field_index(ptype, "sub")
+        field_index = self.model.get_field_index(ptype, SUBJECT_INDEX)
         return self.model.get_values_for_field_in_policy("p", ptype, field_index)
 
     def get_all_objects(self):
@@ -36,7 +37,7 @@ class ManagementEnforcer(InternalEnforcer):
 
     def get_all_named_objects(self, ptype):
         """gets the list of objects that show up in the current named policy."""
-        field_index = self.model.get_field_index(ptype, "obj")
+        field_index = self.model.get_field_index(ptype, OBJECT_INDEX)
         return self.model.get_values_for_field_in_policy("p", ptype, field_index)
 
     def get_all_actions(self):
@@ -45,7 +46,7 @@ class ManagementEnforcer(InternalEnforcer):
 
     def get_all_named_actions(self, ptype):
         """gets the list of actions that show up in the current named policy."""
-        field_index = self.model.get_field_index(ptype, "act")
+        field_index = self.model.get_field_index(ptype, ACTION_INDEX)
         return self.model.get_values_for_field_in_policy("p", ptype, field_index)
 
     def get_all_roles(self):

--- a/tests/test_management_api.py
+++ b/tests/test_management_api.py
@@ -38,6 +38,18 @@ class TestManagementApi(TestCaseBase):
         self.assertEqual(e.get_all_actions(), ["read", "write"])
         self.assertEqual(e.get_all_roles(), ["data2_admin"])
 
+    def test_get_list_with_domains(self):
+        e = self.get_enforcer(
+            get_examples("rbac_with_domains_model.conf"),
+            get_examples("rbac_with_domains_policy.csv"),
+            # True,
+        )
+
+        self.assertEqual(e.get_all_subjects(), ["admin"])
+        self.assertEqual(e.get_all_objects(), ["data1", "data2"])
+        self.assertEqual(e.get_all_actions(), ["read", "write"])
+        self.assertEqual(e.get_all_roles(), ["admin"])
+
     def test_get_policy_api(self):
         e = self.get_enforcer(
             get_examples("rbac_model.conf"),


### PR DESCRIPTION
## Short description

`get_all_named_{things}` functions (things can be `actions`, `subjects`, `roles`) uses hard-coded index for getting "things" from policies, which causes wrong result when using RBAC with domains mode (which a new field `domain` is inserted to the index 1).

The PR does:
- use `Model.get_field_index` for getting correct field index when getting the actions, subjects
- a new testcase is added

## Details

### The root cause

`get_all_named_{things}` functions (things can be `actions`, `subjects`, `roles`) use fixed field index while fetching the corresponding resources, which causes incorrect behavior when the field indexes change.

According to [the documentation](https://casbin.org/docs/rbac-with-domains), the RBAC mode with domains have the convenient putting `domain` as the second param of a policy, while the `subject` is located at the second param (`field_index=1`) in other mode.

> Note: Conventionally, the domain token name in policy definition is `dom` and is placed as the second token `(sub, dom, obj, act)`. 

### Solution of this PR

To make `pycasbin` works correctly, the `field_index` of "things"(`actions`, `subjects`, `roles`) should be determined from the config file (instead of hard-coded). The `Model.get_field_index` method is used in this PR for getting correct index from config.

### What's more

#### Changes to documentation

Now `pycasbin` can detect the position of `dom` and `act`, there's no need to explicitly set the field index of `dom` using `set_field_index` API.

#### Similar situation

Now `get_all_named_roles` is still using hard-coded field index (but it won't fail in RBAC with domains mode), this can be optimized using similar API.

Close #345 