### PR TITLE
feat: Optimise `load_policy_line` to avoid quadratic individual-character loop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
           tests/benchmarks/benchmark_model.py
           tests/benchmarks/benchmark_management_api.py
           tests/benchmarks/benchmark_role_manager.py
+          tests/benchmarks/benchmark_adapter.py
 
       - name: Upload coverage data to coveralls.io
         run: coveralls --service=github

--- a/casbin/persist/adapter.py
+++ b/casbin/persist/adapter.py
@@ -44,8 +44,9 @@ def _extract_tokens(line):
             stack.append(c)
         elif c == "]" or c == ")":
             stack.pop()
-        elif c == "," and len(stack) == 0:
-            # we've found the end of a top level token so save that and start a new one
+        elif len(stack) == 0:
+            # must be a comma outside of any nesting: we've found the end of a top level token so
+            # save that and start a new one
             tokens.append(line[start_idx : match.start()])
             start_idx = match.end()
 

--- a/casbin/persist/adapter.py
+++ b/casbin/persist/adapter.py
@@ -44,7 +44,7 @@ def _extract_tokens(line):
             stack.append(c)
         elif c == "]" or c == ")":
             stack.pop()
-        elif len(stack) == 0:
+        elif not stack:
             # must be a comma outside of any nesting: we've found the end of a top level token so
             # save that and start a new one
             tokens.append(line[start_idx : match.start()])

--- a/casbin/persist/adapter.py
+++ b/casbin/persist/adapter.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def load_policy_line(line, model):
-    """loads a text line as a policy rule to model."""
+def _extract_tokens(line):
+    """Return the list of 'tokens' from the line, or None if this line has none"""
 
     if line == "":
-        return
+        return None
 
     if line[:1] == "#":
-        return
+        return None
 
     stack = []
     tokens = []
@@ -40,6 +40,15 @@ def load_policy_line(line, model):
                 tokens[-1] += c
 
     tokens = [x.strip() for x in tokens]
+    return tokens
+
+
+def load_policy_line(line, model):
+    """loads a text line as a policy rule to model."""
+
+    tokens = _extract_tokens(line)
+    if tokens is None:
+        return
 
     key = tokens[0]
     sec = key[0]

--- a/casbin/persist/adapter.py
+++ b/casbin/persist/adapter.py
@@ -47,13 +47,12 @@ def _extract_tokens(line):
         elif not stack:
             # must be a comma outside of any nesting: we've found the end of a top level token so
             # save that and start a new one
-            tokens.append(line[start_idx : match.start()])
+            tokens.append(line[start_idx : match.start()].strip())
             start_idx = match.end()
 
     # trailing token after the last ,
-    tokens.append(line[start_idx:])
+    tokens.append(line[start_idx:].strip())
 
-    tokens = [x.strip() for x in tokens]
     return tokens
 
 

--- a/tests/benchmarks/benchmark_adapter.py
+++ b/tests/benchmarks/benchmark_adapter.py
@@ -1,0 +1,30 @@
+from casbin.persist.adapter import _extract_tokens
+
+
+def _benchmark_extract_tokens(benchmark, line):
+    @benchmark
+    def run_benchmark():
+        _extract_tokens(line)
+
+
+def test_benchmark_extract_tokens_short_simple(benchmark):
+    _benchmark_extract_tokens(benchmark, "abc,def,ghi")
+
+
+def test_benchmark_extract_tokens_long_simple(benchmark):
+    # fixed UUIDs for length and to be similar to "real world" usage of UUIDs
+    _benchmark_extract_tokens(
+        benchmark,
+        "00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002",
+    )
+
+
+def test_benchmark_extract_tokens_short_nested(benchmark):
+    _benchmark_extract_tokens(benchmark, "abc(def,ghi),jkl(mno,pqr)")
+
+
+def test_benchmark_extract_tokens_long_nested(benchmark):
+    _benchmark_extract_tokens(
+        benchmark,
+        "00000000-0000-0000-0000-000000000000(00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002),00000000-0000-0000-0000-000000000003(00000000-0000-0000-0000-000000000004,00000000-0000-0000-0000-000000000005)",
+    )

--- a/tests/persist/test_adapter.py
+++ b/tests/persist/test_adapter.py
@@ -1,0 +1,53 @@
+from casbin.persist.adapter import _extract_tokens
+from tests import TestCaseBase
+
+
+class TestExtractTokens(TestCaseBase):
+    def test_ignore_lines(self):
+        self.assertIsNone(_extract_tokens(""))  # empty
+        self.assertIsNone(_extract_tokens("# comment"))
+
+    def test_simple_lines(self):
+        # split on top-level commas, strip whitespace from start and end
+        self.assertEqual(_extract_tokens("one"), ["one"])
+        self.assertEqual(_extract_tokens("one,two"), ["one", "two"])
+        self.assertEqual(_extract_tokens("   ignore  \t,\t   external, spaces  "), ["ignore", "external", "spaces"])
+
+        self.assertEqual(_extract_tokens("internal spaces preserved"), ["internal spaces preserved"])
+
+    def test_nested_lines(self):
+        # basic nesting within a single token
+        self.assertEqual(
+            _extract_tokens("outside1()"),
+            ["outside1()"],
+        )
+        self.assertEqual(
+            _extract_tokens("outside1(inside1())"),
+            ["outside1(inside1())"],
+        )
+
+        # split on top-level commas, but not on internal ones
+        self.assertEqual(
+            _extract_tokens("outside1(inside1(), inside2())"),
+            ["outside1(inside1(), inside2())"],
+        )
+        self.assertEqual(
+            _extract_tokens("outside1(inside1(), inside2(inside3(), inside4()))"),
+            ["outside1(inside1(), inside2(inside3(), inside4()))"],
+        )
+        self.assertEqual(
+            _extract_tokens("outside1(inside1(), inside2()), outside2(inside3(), inside4())"),
+            ["outside1(inside1(), inside2())", "outside2(inside3(), inside4())"],
+        )
+
+        # different delimiters
+        self.assertEqual(
+            _extract_tokens(
+                "all_square[inside1[], inside2[]],square_and_parens[inside1(), inside2()],parens_and_square(inside1[], inside2[])"
+            ),
+            [
+                "all_square[inside1[], inside2[]]",
+                "square_and_parens[inside1(), inside2()]",
+                "parens_and_square(inside1[], inside2[])",
+            ],
+        )


### PR DESCRIPTION
This dramatically improves the performance of the `casbin.persist.adapter.load_policy_line` function:

- before: iterate over characters individually and build each token string by `+=`'ing those characters. The latter in particular leads to quadratic performance, based the length of the string (e.g. https://stackoverflow.com/a/34008199/1256624), which is noticeable with "long" lines, like if they contain UUIDs.
- after: use a regex to find the start/end index of each tokens and slice out each token string in one go.

This function was appearing very high in our profiles of initialising our adapters. We have two UUIDs appear in most of our lines.

To make this a safe refactoring, I've pulled out an internal function that does the string manipulation in isolation and tested it.

I've also added a benchmark that demonstrates the performance improvements. Here's the total change of the median time that `pytest-benchmark` reports before and after this change, in microseconds:

| Benchmark                                  | Before | After | Change |
|--------------------------------------------|-------:|------:|-------:|
| `test_benchmark_extract_tokens_long_nested`  |   27.0 |  2.46 |   -91% |
| `test_benchmark_extract_tokens_long_simple`  |   13.6 |  1.42 |   -90% |
| `test_benchmark_extract_tokens_short_nested` |   3.25 |  1.63 |   -50% |
| `test_benchmark_extract_tokens_short_simple` |   1.58 |  0.917 |   -42% |

That is, the "long" tests get 10× faster. Even longer lines will likely see a greater speed-up too.

---

Thanks for casbin!