### PR TITLE
feat: enhance FilteredFileAdapter to handle flexible filtering for policies and roles

### DIFF
--- a/casbin/persist/adapters/filtered_file_adapter.py
+++ b/casbin/persist/adapters/filtered_file_adapter.py
@@ -58,19 +58,17 @@ class FilteredFileAdapter(FileAdapter, FilteredAdapter):
         self.load_filtered_policy_file(model, filter_value, persist.load_policy_line)
         self.filtered = True
 
-    def load_filtered_policy_file(self, model, filter, hanlder):
+    def load_filtered_policy_file(self, model, filter, handler):
         with open(self._file_path, "rb") as file:
-            while True:
-                line = file.readline()
+            for line in file:
                 line = line.decode().strip()
-                if line == "\n":
+                if not line or line == "\n":
                     continue
-                if not line:
-                    break
+                    
                 if filter_line(line, filter):
                     continue
 
-                hanlder(line, model)
+                handler(line, model)
 
     # is_filtered returns true if the loaded policy has been filtered.
     def is_filtered(self):
@@ -92,20 +90,22 @@ def filter_line(line, filter):
         return True
     filter_slice = []
 
-    if p[0].strip() == "p":
-        filter_slice = filter[0]
-    elif p[0].strip() == "g":
+    if p[0].strip() == "g":
+        if not filter[1] or all(not x.strip() for x in filter[1]):
+            return False
         filter_slice = filter[1]
+    elif p[0].strip() == "p":
+        filter_slice = filter[0]
+    
     return filter_words(p, filter_slice)
-
 
 def filter_words(line, filter):
     if len(line) < len(filter) + 1:
         return True
     skip_line = False
     for i, v in enumerate(filter):
-        if len(v) > 0 and (v.strip() != line[i + 1].strip()):
+        if v and v.strip() and (v.strip() != line[i + 1].strip()):
             skip_line = True
             break
-
+    
     return skip_line

--- a/casbin/persist/adapters/filtered_file_adapter.py
+++ b/casbin/persist/adapters/filtered_file_adapter.py
@@ -64,7 +64,7 @@ class FilteredFileAdapter(FileAdapter, FilteredAdapter):
                 line = line.decode().strip()
                 if not line or line == "\n":
                     continue
-                    
+
                 if filter_line(line, filter):
                     continue
 
@@ -96,8 +96,9 @@ def filter_line(line, filter):
         filter_slice = filter[1]
     elif p[0].strip() == "p":
         filter_slice = filter[0]
-    
+
     return filter_words(p, filter_slice)
+
 
 def filter_words(line, filter):
     if len(line) < len(filter) + 1:
@@ -107,5 +108,5 @@ def filter_words(line, filter):
         if v and v.strip() and (v.strip() != line[i + 1].strip()):
             skip_line = True
             break
-    
+
     return skip_line

--- a/casbin/persist/adapters/filtered_file_adapter.py
+++ b/casbin/persist/adapters/filtered_file_adapter.py
@@ -52,6 +52,11 @@ class FilteredFileAdapter(FileAdapter, FilteredAdapter):
 
         try:
             filter_value = [filter.__dict__["P"]] + [filter.__dict__["G"]]
+            is_empty_filter = all(not f for f in filter_value) or all(
+                all(not x.strip() for x in f) if f else True for f in filter_value
+            )
+            if is_empty_filter:
+                return self.load_policy(model)
         except:
             raise RuntimeError("invalid filter type")
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import casbin
+import os
 from unittest import TestCase
+import casbin
 from tests.test_enforcer import get_examples
 from casbin.persist.adapters import FilteredFileAdapter
 from casbin.persist.adapters.filtered_file_adapter import filter_line, filter_words
-import tempfile
-import shutil
-import os
 
 
 class Filter:
@@ -171,7 +169,7 @@ class TestFilteredFileAdapter(TestCase):
         self.assertTrue(e.has_policy(["admin", "domain2", "data2", "read"]))
 
     def test_mixed_empty_filter(self):
-        """测试混合空字符串和非空字符串的过滤器"""
+        """Test the filter for mixed empty and non-empty strings."""
         adapter = FilteredFileAdapter(get_examples("rbac_with_domains_policy.csv"))
         e = casbin.Enforcer(get_examples("rbac_with_domains_model.conf"), adapter)
         filter = Filter()

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -16,6 +16,10 @@ import casbin
 from unittest import TestCase
 from tests.test_enforcer import get_examples
 from casbin.persist.adapters import FilteredFileAdapter
+from casbin.persist.adapters.filtered_file_adapter import filter_line, filter_words
+import tempfile
+import shutil
+import os
 
 
 class Filter:
@@ -141,3 +145,166 @@ class TestFilteredFileAdapter(TestCase):
 
         with self.assertRaises(RuntimeError):
             e.load_filtered_policy(None)
+
+    def test_empty_filter_array(self):
+        """Test filter for empty array."""
+        adapter = FilteredFileAdapter(get_examples("rbac_with_domains_policy.csv"))
+        e = casbin.Enforcer(get_examples("rbac_with_domains_model.conf"), adapter)
+        filter = Filter()
+        filter.P = []
+        filter.G = []
+
+        e.load_filtered_policy(filter)
+        self.assertTrue(e.has_policy(["admin", "domain1", "data1", "read"]))
+        self.assertTrue(e.has_policy(["admin", "domain2", "data2", "read"]))
+
+    def test_empty_string_filter(self):
+        """Test the filter for all empty strings."""
+        adapter = FilteredFileAdapter(get_examples("rbac_with_domains_policy.csv"))
+        e = casbin.Enforcer(get_examples("rbac_with_domains_model.conf"), adapter)
+        filter = Filter()
+        filter.P = ["", "", ""]
+        filter.G = ["", "", ""]
+
+        e.load_filtered_policy(filter)
+        self.assertTrue(e.has_policy(["admin", "domain1", "data1", "read"]))
+        self.assertTrue(e.has_policy(["admin", "domain2", "data2", "read"]))
+
+    def test_mixed_empty_filter(self):
+        """测试混合空字符串和非空字符串的过滤器"""
+        adapter = FilteredFileAdapter(get_examples("rbac_with_domains_policy.csv"))
+        e = casbin.Enforcer(get_examples("rbac_with_domains_model.conf"), adapter)
+        filter = Filter()
+        filter.P = ["", "domain1", ""]
+        filter.G = ["", "", "domain1"]
+
+        e.load_filtered_policy(filter)
+        self.assertTrue(e.has_policy(["admin", "domain1", "data1", "read"]))
+        self.assertFalse(e.has_policy(["admin", "domain2", "data2", "read"]))
+
+    def test_nonexistent_domain_filter(self):
+        """Testing the filter for a non-existent domain."""
+        adapter = FilteredFileAdapter(get_examples("rbac_with_domains_policy.csv"))
+        e = casbin.Enforcer(get_examples("rbac_with_domains_model.conf"), adapter)
+        filter = Filter()
+        filter.P = ["", "domain3"]
+        filter.G = ["", "", "domain3"]
+
+        e.load_filtered_policy(filter)
+        self.assertFalse(e.has_policy(["admin", "domain3", "data3", "read"]))
+
+    def test_empty_filter_array(self):
+        """Test filter for empty array."""
+        adapter = FilteredFileAdapter(get_examples("rbac_with_domains_policy.csv"))
+        e = casbin.Enforcer(get_examples("rbac_with_domains_model.conf"), adapter)
+        filter = Filter()
+        filter.P = []
+        filter.G = []
+
+        try:
+            e.load_filtered_policy(filter)
+        except:
+            raise RuntimeError("unexpected error with empty filter arrays")
+
+        self.assertFalse(e.is_filtered(), "Adapter should not be marked as filtered with empty filters")
+
+        self.assertTrue(e.has_policy(["admin", "domain1", "data1", "read"]))
+        self.assertTrue(e.has_policy(["admin", "domain2", "data2", "read"]))
+
+    def test_empty_string_filter(self):
+        """Test the filter for all empty strings."""
+        adapter = FilteredFileAdapter(get_examples("rbac_with_domains_policy.csv"))
+        e = casbin.Enforcer(get_examples("rbac_with_domains_model.conf"), adapter)
+        filter = Filter()
+        filter.P = ["", "", ""]
+        filter.G = ["", "", ""]
+
+        try:
+            e.load_filtered_policy(filter)
+        except:
+            raise RuntimeError("unexpected error with empty string filters")
+
+        self.assertFalse(e.is_filtered(), "Adapter should not be marked as filtered with empty string filters")
+
+        try:
+            e.save_policy()
+        except:
+            raise RuntimeError("unexpected error in SavePolicy with empty string filters")
+
+        self.assertTrue(e.has_policy(["admin", "domain1", "data1", "read"]))
+        self.assertTrue(e.has_policy(["admin", "domain2", "data2", "read"]))
+
+    def test_mixed_empty_filter(self):
+        """Test the filter for mixed empty and non-empty strings."""
+        adapter = FilteredFileAdapter(get_examples("rbac_with_domains_policy.csv"))
+        e = casbin.Enforcer(get_examples("rbac_with_domains_model.conf"), adapter)
+        filter = Filter()
+        filter.P = ["", "domain1", ""]
+        filter.G = ["", "", "domain1"]
+
+        try:
+            e.load_filtered_policy(filter)
+        except:
+            raise RuntimeError("unexpected error with mixed empty filters")
+
+        self.assertTrue(e.is_filtered(), "Adapter should be marked as filtered")
+
+        with self.assertRaises(RuntimeError):
+            e.save_policy()
+
+        self.assertTrue(e.has_policy(["admin", "domain1", "data1", "read"]))
+        self.assertFalse(e.has_policy(["admin", "domain2", "data2", "read"]))
+
+    def test_whitespace_filter(self):
+        """Test the filter for all blank characters."""
+        adapter = FilteredFileAdapter(get_examples("rbac_with_domains_policy.csv"))
+        e = casbin.Enforcer(get_examples("rbac_with_domains_model.conf"), adapter)
+        filter = Filter()
+        filter.P = [" ", "  ", "\t"]
+        filter.G = ["\n", " ", "  "]
+
+        e.load_filtered_policy(filter)
+
+        self.assertFalse(e.is_filtered())
+        self.assertTrue(e.has_policy(["admin", "domain1", "data1", "read"]))
+        self.assertTrue(e.has_policy(["admin", "domain2", "data2", "read"]))
+
+    def test_filter_line_edge_cases(self):
+        """Test the boundary cases of the filter_line function."""
+        adapter = FilteredFileAdapter(get_examples("rbac_with_domains_policy.csv"))
+
+        self.assertFalse(filter_line("", [[""], [""]]))
+
+        self.assertFalse(filter_line("invalid_line", [[""], [""]]))
+
+        self.assertFalse(filter_line("p, admin, domain1, data1, read", None))
+
+    def test_filter_words_edge_cases(self):
+        """Test the boundary cases of the filter_words function."""
+        self.assertTrue(filter_words(["p"], ["filter1", "filter2"]))
+
+        self.assertFalse(filter_words(["p", "admin", "domain1"], []))
+
+        line = ["admin", "domain1", "data*", "read"]
+        filter = ["", "", "data1", ""]
+        self.assertTrue(filter_words(line, filter))
+
+    def test_load_filtered_policy_with_comments(self):
+        """Test loading filtering policies with comments."""
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
+        try:
+            shutil.copyfile(get_examples("rbac_with_domains_policy.csv"), temp_file.name)
+
+            with open(temp_file.name, "a") as f:
+                f.write("\n# This is a comment\np, admin, domain1, data3, read")
+
+            adapter = FilteredFileAdapter(temp_file.name)
+            e = casbin.Enforcer(get_examples("rbac_with_domains_model.conf"), adapter)
+            filter = Filter()
+            filter.P = ["", "domain1"]
+            filter.G = ["", "", "domain1"]
+
+            e.load_filtered_policy(filter)
+            self.assertTrue(e.has_policy(["admin", "domain1", "data3", "read"]))
+        finally:
+            os.unlink(temp_file.name)


### PR DESCRIPTION
Fix: https://github.com/casbin/pycasbin/issues/361

- The old logic's handling of the g rules is too simplistic. If filter[1] is a null value (indicating there are no g rules to filter), the old logic will still continue to call filter_words for filtering, which may lead to unnecessary misfiltering.
- When filtering g rules, the filter may be a null value. The old logic did not explicitly handle this situation, which could lead to all g rules being skipped (misfiltered).

### Changes
1. Improved Filtering Logic:
- Refactored filter_line and filter_words to distinguish between p and g rules.
- Added explicit handling for empty filters, ensuring that g rules can still be loaded when adapter.filter.G is empty.
2. Optimized Role Rule Handling:
- Ensured that g rules are only filtered when adapter.filter.G contains non-empty criteria, preventing unintentional exclusion of role inheritance relationships.

**Test**
```python
import casbin

if __name__ == "__main__":
     adapter = casbin.persist.adapters.filtered_file_adapter.FilteredFileAdapter(
         "policy.csv"
     )
     adapter.filter.P = ["", "domain1", "", ""]
     adapter.filter.G = ["", "", "domain1"]

     model = casbin.Enforcer.new_model("model.conf")
     filtered_enforcer = casbin.Enforcer(model, adapter)

     filtered_enforcer.load_filtered_policy(filtered_enforcer.adapter.filter)
     print(f"filtered_enforcer.get_policy(): {filtered_enforcer.get_policy()}")

     unfiltered_enforcer = casbin.Enforcer("model.conf", "policy.csv")
     print(f"unfiltered_enforcer.get_policy(): {unfiltered_enforcer.get_policy()}")

     request_vals = ["alice", "domain1", "data1", "read"]

     print(f"request to filtered_enforcer: {filtered_enforcer.enforce(*request_vals)} (expected True)") 
     print(f"request to unfiltered_enforcer: {unfiltered_enforcer.enforce(*request_vals)} (expected True)") 

     print("Filtered Policy Rules:", filtered_enforcer.get_policy())
     print("Filtered Role Rules:", filtered_enforcer.get_grouping_policy())

     print("Before filtering:", unfiltered_enforcer.get_policy())
     print("After filtering:", filtered_enforcer.get_policy())
     print("Role assignments:", filtered_enforcer.get_grouping_policy())
```

**Return**
```
filtered_enforcer.get_policy(): [['admin', 'domain1', 'data1', 'read'], ['admin', 'domain1', 'data1', 'write']]
unfiltered_enforcer.get_policy(): [['admin', 'domain1', 'data1', 'read'], ['admin', 'domain1', 'data1', 'write'], ['admin', 'domain2', 'data2', 'read'], ['admin', 'domain2', 'data2', 'write']]
request to filtered_enforcer: True (expected True)
request to unfiltered_enforcer: True (expected True)
Filtered Policy Rules: [['admin', 'domain1', 'data1', 'read'], ['admin', 'domain1', 'data1', 'write']]
Filtered Role Rules: [['alice', 'admin', 'domain1']]
Before filtering: [['admin', 'domain1', 'data1', 'read'], ['admin', 'domain1', 'data1', 'write'], ['admin', 'domain2', 'data2', 'read'], ['admin', 'domain2', 'data2', 'write']]
After filtering: [['admin', 'domain1', 'data1', 'read'], ['admin', 'domain1', 'data1', 'write']]
Role assignments: [['alice', 'admin', 'domain1']]
```