### PR TITLE
feat: fix bug that get_all_subjects() and similar APIs get wrong result

### DIFF
--- a/casbin/async_management_enforcer.py
+++ b/casbin/async_management_enforcer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from casbin.async_internal_enforcer import AsyncInternalEnforcer
 from casbin.model.policy_op import PolicyOp
+from casbin.constant.constants import ACTION_INDEX, SUBJECT_INDEX, OBJECT_INDEX
 
 
 class AsyncManagementEnforcer(AsyncInternalEnforcer):
@@ -22,27 +23,30 @@ class AsyncManagementEnforcer(AsyncInternalEnforcer):
 
     def get_all_subjects(self):
         """gets the list of subjects that show up in the current policy."""
-        return self.get_all_named_subjects("p")
+        return self.model.get_values_for_field_in_policy_all_types_by_name("p", SUBJECT_INDEX)
 
     def get_all_named_subjects(self, ptype):
         """gets the list of subjects that show up in the current named policy."""
-        return self.model.get_values_for_field_in_policy("p", ptype, 0)
+        field_index = self.model.get_field_index(ptype, SUBJECT_INDEX)
+        return self.model.get_values_for_field_in_policy("p", ptype, field_index)
 
     def get_all_objects(self):
         """gets the list of objects that show up in the current policy."""
-        return self.get_all_named_objects("p")
+        return self.model.get_values_for_field_in_policy_all_types_by_name("p", OBJECT_INDEX)
 
     def get_all_named_objects(self, ptype):
         """gets the list of objects that show up in the current named policy."""
-        return self.model.get_values_for_field_in_policy("p", ptype, 1)
+        field_index = self.model.get_field_index(ptype, OBJECT_INDEX)
+        return self.model.get_values_for_field_in_policy("p", ptype, field_index)
 
     def get_all_actions(self):
         """gets the list of actions that show up in the current policy."""
-        return self.get_all_named_actions("p")
+        return self.model.get_values_for_field_in_policy_all_types_by_name("p", ACTION_INDEX)
 
     def get_all_named_actions(self, ptype):
         """gets the list of actions that show up in the current named policy."""
-        return self.model.get_values_for_field_in_policy("p", ptype, 2)
+        field_index = self.model.get_field_index(ptype, ACTION_INDEX)
+        return self.model.get_values_for_field_in_policy("p", ptype, field_index)
 
     def get_all_roles(self):
         """gets the list of roles that show up in the current named policy."""

--- a/casbin/management_enforcer.py
+++ b/casbin/management_enforcer.py
@@ -24,7 +24,7 @@ class ManagementEnforcer(InternalEnforcer):
 
     def get_all_subjects(self):
         """gets the list of subjects that show up in the current policy."""
-        return self.get_all_named_subjects("p")
+        return self.model.get_values_for_field_in_policy_all_types_by_name("p", SUBJECT_INDEX)
 
     def get_all_named_subjects(self, ptype):
         """gets the list of subjects that show up in the current named policy."""
@@ -33,7 +33,7 @@ class ManagementEnforcer(InternalEnforcer):
 
     def get_all_objects(self):
         """gets the list of objects that show up in the current policy."""
-        return self.get_all_named_objects("p")
+        return self.model.get_values_for_field_in_policy_all_types_by_name("p", OBJECT_INDEX)
 
     def get_all_named_objects(self, ptype):
         """gets the list of objects that show up in the current named policy."""
@@ -42,7 +42,7 @@ class ManagementEnforcer(InternalEnforcer):
 
     def get_all_actions(self):
         """gets the list of actions that show up in the current policy."""
-        return self.get_all_named_actions("p")
+        return self.model.get_values_for_field_in_policy_all_types_by_name("p", ACTION_INDEX)
 
     def get_all_named_actions(self, ptype):
         """gets the list of actions that show up in the current named policy."""

--- a/casbin/model/policy.py
+++ b/casbin/model/policy.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from casbin.util import util
 
 DEFAULT_SEP = ","
 
@@ -316,5 +317,20 @@ class Policy:
             value = rule[field_index]
             if value not in values:
                 values.append(value)
+
+        return values
+
+    def get_values_for_field_in_policy_all_types_by_name(self, sec, field):
+        """gets all values for a field for all rules in a policy of all ptypes, duplicated values are removed."""
+        values = []
+        if sec not in self.keys():
+            return values
+
+        for ptype in self[sec]:
+            index = self.get_field_index(ptype, field)
+            value = self.get_values_for_field_in_policy(sec, ptype, index)
+            values.extend(value)
+
+        values = util.array_remove_duplicates(values)
 
         return values


### PR DESCRIPTION
Continue: https://github.com/casbin/pycasbin/pull/346

fix: fix the bug that get_all_{thing} has wrong result in RBAC with domains model. Previously, #346 has fixed the get_all_named_{thing} function but it did not fix get_all_{thing} function and those functions in async pycasbin.